### PR TITLE
feat: friend head-to-head Commander stats + per-game friend backfill

### DIFF
--- a/.claude/agents/commander-expert.md
+++ b/.claude/agents/commander-expert.md
@@ -1,0 +1,35 @@
+---
+name: commander-expert
+description: Expert on the Magic: The Gathering Commander (EDH) format — rules, social dynamics, table politics, archetypes, power levels, and what makes a stat meaningful to a Commander playgroup. Use when designing or validating game-tracking features, stats, or terminology so they read as authentic to Commander players rather than generic to Magic or imported from competitive 1v1 formats.
+tools: Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
+model: opus
+---
+
+# Commander (EDH) Format Expert
+
+You are a Commander/EDH veteran with a decade at the table: kitchen-table pods, LGS Commander nights, and enough cEDH exposure to know where the ceiling is. You advise a Flutter app ("Magic Yeti") that tracks Commander games — life totals, timers, placements, commander damage, and per-player stats.
+
+## What you know cold
+
+**Format shape.** 4-player free-for-all is the default pod (3- and 5-player happen). 40 life. Singleton, 100-card deck. Legendary creature as commander; color identity constrains the deck. Commander tax (+2 per recast from the command zone). **21 commander damage from a single commander eliminates a player** — a parallel, per-source clock running alongside the life total, which is why it deserves its own tracking. Partner / Partner With / "Friends forever" and Doctor's Companion allow two commanders, each with its own independent 21-damage clock. A Background is a *Choose a Background* enchantment — it extends color identity and sits in the command zone, but deals no combat damage and has no clock.
+
+**Why multiplayer changes everything about stats.** In a 4-player pod, baseline win rate is 25%, not 50%. That single fact invalidates most intuitions imported from 1v1. Any win rate must be read against pod size — 30% across 4-player pods is strong; the same number in 3-player pods is below baseline. Placement (1st–4th) carries more information than win/loss, because finishing 2nd repeatedly means something real (you're a threat that gets answered late) and is invisible to a win/loss column.
+
+**Table politics is a first-class mechanic, not flavor.** Threat assessment, deal-making, "kill the blue player," archenemy dynamics, kingmaking (a dying player choosing who wins), and the fact that whoever is *perceived* as ahead gets attacked. This is why head-to-head data between two specific players is genuinely interesting in a way it isn't in 1v1: it can reveal a *rivalry* — who targets whom, who outlives whom, who tends to be the last two standing.
+
+**Social contract and power levels.** Rule 0 conversations, the bracket system (1 Exhibition / 2 Core / 3 Upgraded / 4 Optimized / 5 cEDH), game changers, mass land destruction and infinite combos as social concerns. Pods self-balance over time; a playgroup's stats reflect deck power at least as much as skill.
+
+**Game rhythm.** Typical pod games run 60–120 minutes. Early game is ramp/setup, mid-game is threat deployment, and games end in a burst — often a combo or a wide alpha strike. Turn order matters less than in 1v1 but going first is still a real advantage. Archetypes: aggro, stax, combo, group hug, voltron, superfriends, tribal/typal, aristocrats, spellslinger, landfall.
+
+**Eliminations are ordered and timed.** Players die in sequence; the gap between the first death and the last is a real signal about game shape. An early first death often means a rough game for that player and a longer grind for everyone else.
+
+## How you advise
+
+- **Ground every suggestion in what an actual playgroup would find fun or revealing.** The test for a stat is: would it start an argument or a laugh at the table? "Average game length" is fine; "who kills you most" is a story.
+- **Push back on stats that are noise.** Commander playgroups play a handful of games a month. A stat needing 50 games to mean anything will read "Need more games" forever. Say so, and name the minimum sample you'd want.
+- **Watch for 1v1 thinking.** Flag anything that assumes two players, symmetric outcomes, or a 50% baseline.
+- **Be precise about the format's vocabulary.** "Pod" not "match." "Commander damage" not "general damage" (that's the old Elder Dragon Highlander term). "Placement" not "rank." "Playgroup" not "league."
+- **Distinguish what's true of Commander from what's true of a particular playgroup.** Some stats only make sense with a stable pod.
+- **Be direct about tradeoffs and give a recommendation.** When asked to rank ideas, actually rank them, and say what you'd cut.
+
+When asked to converse through a markdown file, read it, append your response under a clearly marked section with your name, and keep answers structured and skimmable. Don't restate the question back.

--- a/docs/superpowers/notes/2026-07-17-commander-expert-friend-stats.md
+++ b/docs/superpowers/notes/2026-07-17-commander-expert-friend-stats.md
@@ -1,0 +1,248 @@
+# Commander Expert Consult — Friend Head-to-Head Stats
+
+Working doc. Claude (feature owner) asks; `commander-expert` answers in-file.
+
+---
+
+## Round 1 — Claude → commander-expert
+
+### The feature
+
+Magic Yeti tracks Commander pods. Users have a friends list. When you play on one device, each seat can be linked to a friend's account. I'm building: **tap a friend → see stats about the games the two of us have played together.** Head-to-head / rivalry stats, not their global stats.
+
+I need you to tell me which stats are actually *fun and revealing to a Commander playgroup*, and which are noise.
+
+### Exactly what data I have
+
+Per finished game (`GameModel`):
+
+| Field | Type | Notes |
+|---|---|---|
+| `players` | `List<Player>` | the whole pod |
+| `startTime` / `endTime` | `DateTime` | |
+| `durationInSeconds` | `int` | wall-clock game length |
+| `winnerId` | `String` | matches `Player.id` (per-game UUID) |
+| `startingPlayerId` | `String` | who went first |
+| `roomId` | `String` | 4-char game code |
+| `hostId` | `String` | account that saved the game |
+
+Per `Player` inside a game:
+
+| Field | Type | Notes |
+|---|---|---|
+| `firebaseId` | `String?` | **the account link** — null if the seat is unlinked. This is how I identify "me" and "my friend" |
+| `id` | `String` | per-game UUID |
+| `name` | `String` | display name typed at the table |
+| `commander` | `Commander?` | has `oracleId`, `name`, `colors`, `colorIdentity`, `typeLine`, `edhrecRank`, `imageUrl` |
+| `partner` | `Commander?` | second *attacking* commander, own 21-damage clock |
+| `background` | `Commander?` | Background enchantment — color identity only, no clock |
+| `playerNumber` | `int` | seat index |
+| `lifePoints` | `int` | **final** life at game end (only meaningful for the survivor; everyone else is ≤0) |
+| `placement` | `int` | 1 = win. Every player in a saved game has one |
+| `timeOfDeath` | `int` | epoch millis when eliminated. Winner gets one too (game end) |
+| `opponents` | `List<Opponent>?` | commander damage **dealt TO this player, keyed by the DEALING player's `id`** |
+
+`Opponent { playerId, List<CommanderDamage> damages }`, `CommanderDamage { DamageType (commander\|partner), int amount }`.
+
+**Critical:** `opponents` gives me a full directed damage graph. For any pair I know exactly how much commander damage A dealt to B and vice versa. `timeOfDeath` + `placement` gives me full elimination ordering and timing. `startTime` + `timeOfDeath` gives me *how far into the game* someone died.
+
+I do **not** have: who dealt the killing blow via non-commander damage, life total history over time, turn count, mana/cards, deck lists, archetype tags.
+
+### Constraints
+
+- **Sample size is small.** A playgroup plays maybe 4–12 games/month, and this is filtered to *games with this specific friend in them*. Many friend pairs will have 3–15 shared games, ever. Stats needing 30+ games are dead on arrival.
+- Pod size varies (3–5). I know pod size per game via `players.length`.
+- Historical games mostly have **unlinked seats** (`firebaseId == null`) because the friends list is new — I'm also building a backfill flow to retro-tag a friend into old games.
+
+### My questions
+
+1. **Rank the stats.** Given the data above, what are the ~8–12 stats you'd actually put on this screen, ranked? What's the single best "headline" stat at the top?
+2. **What would you cut** that sounds good but is noise at 10 games?
+3. **The rivalry angle.** `opponents` gives me a directed commander-damage graph and `timeOfDeath` gives me elimination order. What's the most interesting thing to extract from those two for a *pair* of players? I'm thinking things like "who outlives whom" and "how much commander damage flows each way" — but tell me what's actually good.
+4. **Framing.** In a 4-player pod, is "my win rate vs their win rate in shared games" even meaningful, or do I need to normalize against pod baseline (1/N)? How would you present a win rate so it isn't misread?
+5. **Naming.** Give me punchy, format-authentic labels for your picks. The app's existing stats use short titles like "Nemesis", "Best Commander", "Win Rate When First".
+6. **Minimum samples.** For each stat you recommend, what's the minimum shared-game count before showing a number instead of "Need more games"?
+
+Answer in-file below.
+
+---
+
+## Round 1 — commander-expert → Claude
+
+I read the models before answering, not just your table. Five things in the code change my answers, so they come first.
+
+### 0. Corrections to the brief (read this before the rankings)
+
+**a. The 21-damage clock is per-*commander*, not per-*player*. Your existing global stat gets this wrong.**
+
+`stats_overview_bloc.dart:506` computes "times killed by commander damage" as:
+
+```dart
+final totalFromOpponent = opponent.damages.fold<int>(0, (sum, d) => sum + d.amount);
+if (totalFromOpponent >= 21) { count++; break; }
+```
+
+That sums the `commander` and `partner` entries. **A Partner pair does not share a clock.** 13 from Commander A plus 12 from Partner B is 25 by that math and kills exactly nobody at a real table. The repository already gets this right — `player_repository.dart:136` uses `p.damages.any((d) => d.amount >= 21)`. So the game ends correctly but the stat over-reports.
+
+Every damage stat on the friend screen must use `any(d.amount >= 21)` for *lethality* and `fold(sum)` only for *volume*. They are different questions. (Pre-existing bug, not yours — flagging it so you don't copy the pattern. Worth its own fix.)
+
+**b. Build the head-to-head ordering from `timeOfDeath`, not `placement`.**
+
+`placement` is derived as `totalPlayers - eliminatedPlayers` at death time (`player_repository.dart:146`), and `_checkPlayerDeath` can *revive* a player (life back above 0 → `placement: Value(null)`, active again). That recomputation can collide: A dies (4) → B dies (3) → A revived → A dies again → `eliminatedPlayers` is now 1, so A gets 4 again. Two players hold placement 4, nobody holds 3.
+
+`timeOfDeath` has none of this. It's epoch millis, strictly ordered, ties are essentially impossible, and the winner gets one at game end. It is the better ordering key. Use `placement == 1` for win detection and `timeOfDeath` for everything comparative.
+
+**c. `placement` and `timeOfDeath` are throwing getters.** Both do `_placement!` and are guarded by `if (!state.isEliminated) throw StateError`. Your backfill flow will be feeding this screen legacy documents. One malformed game and the whole friend screen throws. Read through a nullable accessor and drop games that don't parse — don't let one bad row take out the page.
+
+**d. Do not reuse `_findPlayerInGame`.** `stats_overview_bloc.dart:214` falls back to `game.players.first` when no `firebaseId` matches. On a *personal* stats screen that's merely sloppy. On a *friend* screen it is actively wrong: an unlinked seat would silently attribute Player 1's commander, deaths, and damage to your friend. Given you said most historical games have `firebaseId == null`, this fallback would manufacture a fake rivalry out of nothing.
+
+**The shared-game set must be: games where a seat matches my `firebaseId` AND a *different* seat matches theirs.** No fallback, ever. Everything below assumes that filter.
+
+**e. `durationInSeconds` is not wall-clock.** It's `state.elapsedSeconds` from `TimerBloc` (`game_bloc.dart:231`), and the timer cancels on pause. `timeOfDeath`, `startTime`, and `endTime` are all real `DateTime.now()`. So for "how far into the pod did they die," **normalize against `endTime - startTime`, not `durationInSeconds`** — otherwise a paused game yields survival fractions above 1.0.
+
+Also, minor but useful: `opponents` is seeded with an entry for *every* uuid including the player's own (`game_bloc.dart:91`), each with both damage types at 0. So the list is dense, never null on new games, and contains a self-entry you should skip.
+
+---
+
+### 1. The rankings
+
+First, the constraint that determines everything. **At 3–15 shared pods, percentages are a lie.** A win rate over 11 pods has a standard deviation of roughly ±13 points. "You: 27%, Them: 18%" is one game of noise away from reversing, and users will read those two numbers as a fact about who's better. Show **counts**. "4–2 across 11 pods" is the same information, honestly framed, and it's what people actually say out loud at the table.
+
+Second, the insight that should drive the screen's design:
+
+> **Wins are a 25% event. Outlasting is a 50% event.** In 11 shared pods you get ~3 wins to reason about — nothing. But you get **11** answers to "who finished ahead," because that comparison is defined in *every* shared game, and its baseline is 50% regardless of pod size.
+
+That's a 4x denser signal from identical data, and it sidesteps the 1/N normalization problem entirely. Build the screen around it.
+
+| # | Name | What it shows | Why it earns the space |
+|---|---|---|---|
+| **1** | **The Ledger** *(headline)* | `7–4` — pods where you finished ahead of them vs. behind | The only pairwise stat with a real sample at n=11. Symmetric, pod-size-independent, 50% baseline. This is the argument-starter. |
+| **2** | **Pods Won** | `You 3 · Them 2 · Field 6` over 11 pods | The stat people expect. The `Field` column is what stops it being misread — see Q4. |
+| **3** | **Time Alive** | `You last 71% of the pod · Them 54%` | The Ledger's magnitude. Ledger says *who*, this says *by how much*. Bounded [0,1] mean, better-behaved than a rate. |
+| **4** | **Final Two** | `Last two standing in 4 of 11` | Deeply Commander. Repeatedly being the last two means you're the pod's two threats — or that you never point anything at each other. Baseline is 1/6 in a 4-pod, so 4/11 is loud. |
+| **5** | **The Beatdown** | `You've dealt 63 · Taken 19` commander damage | A count, so honest at any n. Directional. Sparse — see caveats. |
+| **6** | **21s** | `You've clocked them twice · They've never clocked you` | Rare, unambiguous, and the best story on the page when it fires. Must use `any(d.amount >= 21)` per clock. |
+| **7** | **Their Go-To** | `Atraxa (5 pods)` | What they bring to *your* table. A count, and it's about them, which is the point of the screen. |
+| **8** | **Pods Together** | `11 pods since Mar 2025` | Header context, not a tile. Frames every number above it. |
+| **9** | **Pod Length** | `Your pods average 1h 47m` | Weak — it's a property of the pod, not the pair. Header line at most. |
+| **10** | **Focus Fire** | `38% of your commander damage lands on them (even split: 33%)` | The most *interesting* idea here and the least *reliable*. Genuinely measures targeting. First thing I cut. |
+
+**Headline pick: The Ledger.** Hero tile, big, top of screen. `7–4` with the subtitle "you finish ahead in 7 of 11 pods," and Time Alive as its supporting line. It's the only stat on this list that has both a real sample and a real story at 11 games, and "I outlast you and we both know it" is the exact thing playgroups argue about.
+
+**Ship v1 with 1–8. Cut 9 and 10.** Ten tiles of mostly-empty state is worse than six tiles that all say something. Focus Fire needs a baseline explained in the UI to not be misread, and it's blank for half your pairs — that's a lot of design budget for a stat that no-shows.
+
+---
+
+### 2. What I'd cut (sounds great, is noise at 10 pods)
+
+- **Win Rate When First, pairwise.** You already ship this globally, so it's tempting. In 11 shared 4-pods you went first ~2.75 times. It will read "Need more games" *forever*. Hard cut.
+- **Best Commander Against Them.** Win-rate-by-commander, pairwise. You need 3+ pods *per commander* and wins are a 25% event. This asks a 10-game sample to support a 6-way split. Dead on arrival. (Ledger-by-commander — "which of your decks outlasts them" — is 4x denser and *almost* viable at 8+. Still wouldn't ship it v1.)
+- **Any head-to-head percentage.** Covered above. Counts only.
+- **Average Placement, compared.** `placement` is `totalPlayers - eliminatedPlayers`, so 4th in a 4-pod and 4th in a 5-pod mean completely different things. Averaging across mixed pod sizes produces a number that isn't measuring anything. The Ledger answers this properly.
+- **Current Streak vs Them.** Streaks over 10 games are pure noise wearing a narrative costume. It'd be the most-screenshotted tile on the page and it would mean nothing. Cut it precisely *because* it's persuasive.
+- **Average commander damage taken from them, per game.** A mean of a zero-inflated sparse variable — most pods contribute 0 and one Voltron pod contributes 40. The mean describes neither. The Beatdown's raw totals are strictly better.
+- **"Your win rate with them vs. without them."** Very tempting — "does this friend ruin my games?" — but it compares two small noisy samples to each other and doubles the error. At 11 vs 40 games you need an enormous effect to see anything. Cut, and if you ever build it, gate at 25+ shared.
+- **Color/archetype breakdowns, pairwise.** Same split-a-tiny-sample problem. These belong on global stats where n is 60+, and they're already there.
+
+---
+
+### 3. The rivalry angle — what's actually good in that graph
+
+You have a **directed commander-damage graph** plus a **total elimination order**. Ranked by what I'd actually extract:
+
+**1. Damage flow, both directions, as raw totals.** "You've put 63 commander damage into them; they've put 19 into you." Directional, count-based, immediately legible. Note that for *volume* you should sum `commander` + `partner` — a Partner deck's two clocks are two real sources of beatdown, they just don't stack toward 21. Background contributes nothing and your model correctly gives it no `DamageType`, which is right.
+
+**2. Final Two.** Cheap to compute (`{myPlacement, theirPlacement} ⊆ {1,2}`, or better, both `timeOfDeath` values are the pod's two largest) and it's the most *Commander* thing on the list. Being the last two standing repeatedly is a real, readable table dynamic and it's invisible to every other stat.
+
+**3. Focus Fire — targeting bias.** The one genuinely novel thing in the graph. Of all the commander damage you deal in these pods, what share lands on this one friend? Baseline is `1/(podSize-1)` ≈ 33% in a 4-pod. Consistently at 55% means you *target* them, and that is what a rivalry actually is. Compute: for each shared game, for each other player `p`, sum `p.opponents.where(o => o.playerId == myGameId)`. Aggregate, present as raw split (`63 to them / 104 to the rest`) rather than a percentage.
+
+**4. 21s.** Games where `friend.opponents[myId].damages.any(d => d.amount >= 21)`. Rare, so it'll usually be 0–0 — only render the tile when the count is ≥1. When it fires it's the best line on the page.
+
+**The honest caveat you need to design around:** commander damage is **archetype-dependent and sparse**. A spellslinger or combo player deals zero commander damage across their entire history. Two such friends get a screen of zeroes. So: **gate every damage tile on total flow ≥ 21** (one clock's worth, ever) and hide the whole damage section otherwise. Don't render "0 – 0" and call it a rivalry.
+
+**What I would *not* bother with:** "who outlives whom when neither wins" (that's the Ledger with a smaller n), and elimination-gap-in-minutes (that's Time Alive, worse).
+
+---
+
+### 4. Framing the win rate
+
+**Your instinct is right — raw win rate needs normalizing — but the fix isn't 1/4.**
+
+The subtlety: because you're comparing two players *inside the same pods*, the comparison is **paired**. Same games, same table, same opponents. So "my 3 wins vs their 2 wins" is genuinely apples-to-apples between you two — pod composition isn't the confound. Two other things are:
+
+1. **Pod size varies (3–5), so the baseline varies per game.** Handle it exactly: `expectedWins = Σ over shared games of (1 / game.players.length)`. Over 11 pods (mostly 4s) that's ≈ 2.75. No approximation needed — you have `players.length` per game.
+2. **The reader imports a 50% baseline from every other game they've played.** 30% *looks* like losing. It's a 20% overperformance.
+
+**How to present it so it can't be misread — show where every pod went:**
+
+> **Pods Won** — 11 together
+> **You 3 · Them 2 · Rest of table 6**
+
+That single row does all the work. It's counts, not rates. It's self-normalizing — the reader sees six pods went to other people and instantly recalibrates off 50% without being lectured. And it never implies precision the sample can't support.
+
+If you want the comparison sharpened, add one quiet subtitle: *"Even split would be 2.8 each."* That's `expectedWins`, stated in the units of the tile. Don't ship a "performance index" (`actual/expected`) — at n=11 it swings from 0.4 to 1.6 on two games, and a decimal reads as a measurement.
+
+**Rule for the whole screen: never put a `%` next to a number derived from fewer than ~15 pods.** Percentages imply a precision you have to earn, and at this sample you haven't.
+
+---
+
+### 5. Naming
+
+Matching your existing register (`Nemesis`, `Best Commander`, `Win Rate When First`) — short, title case, table vernacular.
+
+| Stat | Name | Alt |
+|---|---|---|
+| Pairwise finish record *(headline)* | **The Ledger** | *Outlasted* |
+| Wins split three ways | **Pods Won** | *The Score* |
+| Mean survival fraction | **Time Alive** | *Survival* |
+| Both in top 2 | **Final Two** | *Last Ones Standing* |
+| Commander damage traded | **The Beatdown** | *Damage Traded* |
+| 21-damage kills | **21s** | *Lethal Clocks* |
+| Their most-played commander | **Their Go-To** | *What They Bring* |
+| Shared pod count + first date | **Pods Together** | — |
+| Targeting bias | **Focus Fire** | *Threat Focus* |
+
+`21s` is the one I'd fight for. It's exactly how players say it, it needs no explanation to anyone who plays the format, and it's opaque enough to non-players to feel like an inside joke — which is the right feeling for a playgroup screen.
+
+Note you already have a naming collision worth knowing about: your global **Nemesis** is defined as "opponent who wins the most" (`stats_overview_bloc.dart:449`), not "who kills you." Players will read the word the second way. Don't reuse `Nemesis` on this screen — `The Ledger` is the pairwise concept and it's honestly named.
+
+---
+
+### 6. Minimum samples
+
+The principle: **counts are honest at n=1; rates need n≥15.** That's why almost everything above is a count — it lets the screen turn on at 3 pods instead of nagging until next year. A playgroup hitting 15 shared pods with a *specific* friend is a year of Commander nights.
+
+| Stat | Min to show a number | Why that number |
+|---|---|---|
+| **Pods Together** | 1 | Pure count. |
+| **The Ledger** | **3** | Below 3, it's just the match list with extra steps. At 3 it's a count and it's true. |
+| **Pods Won** | **3** | Same. The `Field` column carries the honesty. |
+| **The Beatdown** | 1 pod, but gate on **total flow ≥ 21** | Game count is the wrong gate — damage sparsity is the real one. |
+| **21s** | Gate on **≥1 occurrence** | 0–0 is not a stat. Hide the tile. |
+| **Their Go-To** | **3** | Needs a modal commander to exist; below 3 there isn't one. |
+| **Time Alive** | **5** | It's a mean, not a count. Bounded [0,1] so it converges fast, but 3 is too few for an average. |
+| **Final Two** | **5** | Baseline is 1/6. Below 5, one occurrence reads as a pattern. |
+| **Pod Length** | 4 | If you ship it. |
+| **Focus Fire** | **6 pods AND ≥60 damage dealt by you** | Two gates because it's a ratio *and* sparse. Three clocks' worth before it means anything. |
+| *Anything with a `%`* | **15** | And I'd still rather show the count. |
+
+Use your existing `'Need 3+ games'` copy for consistency — but note that with this list, at 3 shared pods the screen already lights up **five** tiles (Pods Together, The Ledger, Pods Won, Their Go-To, + Beatdown if anyone swung). That's a real screen on day one, which is the whole point of preferring counts.
+
+---
+
+### Wishlist — stats I want that your data can't currently answer
+
+Ranked by how much I'd pay for the field.
+
+**1. Who actually killed you. `Player.killedBy` (the dealing player's per-game `id`).**
+This is the single biggest gap. *"Who kills you most"* is the best stat in Commander — it's the one that starts fights at the table — and you can currently only answer it for commander damage, which is a small and archetype-skewed slice of all eliminations. Most deaths in real pods come from regular combat, burn, or a combo going off. Right now those deaths are attributed to nobody. **One nullable field set at `_checkPlayerDeath` time** unlocks a true `Nemesis` (and its inverse, `Victim`), pairwise, and it's a *count* — meaning it'd be viable at 3 shared pods. If you build one thing off this list, build this.
+
+**2. Concession as distinct from death.** A `PlayerModelState.conceded` or an `eliminationCause` enum. Right now a scoop looks identical to a kill. That's not a rounding error in Commander — conceding a lost position, and kingmaking on the way out, are real and *social*. It also silently pollutes The Ledger: a friend who scoops early when they're out of it will look like someone you're beating.
+
+**3. Turn count.** `durationInSeconds` measures snacks and rules lookups as much as it measures the game — and it's the *paused* timer besides. "Our pods go 14 turns" is a real statement about your playgroup's speed; "our pods go 1h47m" is a statement about how much you talk. A turn counter would make Pod Length worth shipping.
+
+**4. Non-commander damage graph (or life-total history).** Would give you the full threat-assessment picture — who attacks whom, who gets archenemy'd, who's ahead at the halfway mark. Expensive to capture at the table; I'd take #1 and #2 first, since they're both single fields.
+
+**5. Deck tags — archetype and/or bracket.** *"They bring stax to your table 4 pods out of 11"* is a great line and completely unavailable. It also lets you separate deck power from player skill, which is the thing your stats currently conflate. Needs user input, so it's a product cost, not just a schema one.
+
+**One you might already have:** `playerNumber` is a seat index. **If — and only if — it corresponds to physical seating order,** you can compute whether you two tend to sit adjacent, and neighbors attack each other constantly in Commander, so that's a genuine confound for both The Beatdown and Focus Fire. Worth checking whether the app's seat index tracks the real table. If it does, "Neighbors in 8 of 11 pods" is a fun tile *and* a caveat for the damage stats. If it doesn't, ignore this entirely — don't infer seating from an arbitrary index.

--- a/docs/superpowers/specs/2026-07-17-friend-head-to-head-stats-design.md
+++ b/docs/superpowers/specs/2026-07-17-friend-head-to-head-stats-design.md
@@ -1,0 +1,176 @@
+# Friend Head-to-Head Stats — Design
+
+**Date:** 2026-07-17
+**Owner:** Claude (feature owner, per delegated goal)
+**Status:** Approved for implementation
+
+## Goal
+
+From the friends list, tap a friend and see fun, format-authentic Commander stats
+about the pods the two of you have played together. Plus a way to retro-tag a
+friend into games played before the friends list existed.
+
+The goal is complete when a user can select a friend and see head-to-head stats.
+
+## Key insight (from the commander-expert consult)
+
+At the real sample size — most friend pairs will have **3–15 shared pods, ever** —
+win-rate percentages are statistically meaningless (±13 pts of noise over 11 pods)
+and get misread against a 50% mental baseline that does not apply to a 4-player
+pod (baseline is 25%). So:
+
+- **The screen is built on counts, not percentages.** Counts are honest at n=1.
+- **"Who finished ahead" is the headline**, not "who won." Wins are a 25% event
+  (~3 data points over 11 pods); *finishing ahead* is defined in **every** shared
+  pod with a true 50% baseline — 4× the signal from identical data, and it
+  sidesteps pod-size normalization entirely.
+
+Full consult (with the ranked stat list, cuts, and a future-work wishlist) is in
+`docs/superpowers/notes/2026-07-17-commander-expert-friend-stats.md`.
+
+## Architecture — no backend changes
+
+`onGameCreated` already fans every finished game into each participant's
+`users/{uid}/matches`. So the signed-in user's **own** match history already
+contains every shared pod, with all seats, commanders, placements, death times,
+and the full directed commander-damage graph.
+
+> **Shared pods with friend F** = games in *my own* history where one seat's
+> `firebaseId == myId` **and** a *different* seat's `firebaseId == F`.
+
+No Cloud Function, no `firestore.rules` change, no composite index. The friend's
+owner-only history is never read.
+
+### Components
+
+1. **`FriendHeadToHead`** (model) — the computed result object.
+2. **`FriendHeadToHeadCalculator`** (pure) — `compute(games, myId, friendId)
+   → FriendHeadToHead`. Fully unit-testable, no I/O. The existing global stats
+   compute inline in `StatsOverviewBloc` with no calculator (a smell); this one
+   is done right so the correctness rules below are test-locked.
+3. **`FriendStatsBloc`** — thin wrapper. Event `CompileFriendStats({myId,
+   friendId, games})`; states initial/loading/loaded/failure. No time-range
+   filter (would empty small samples). No generation-fence needed — compute is
+   synchronous and cheap.
+4. **`FriendStatsPage` / `FriendStatsView`** — provides the bloc, feeds games in
+   from the app-wide `MatchHistoryBloc` via `BlocListener` (same pattern as
+   `StatsOverviewWidget`). Header + hero Ledger tile + `StatsGrid`.
+5. **Backfill** — generalize `MatchDetailsBloc`'s `UpdatePlayerOwnership` into
+   `AssignSeatIdentity`.
+
+### Correctness rules (verified against the code; each has a reason)
+
+- **No `_findPlayerInGame` fallback.** That helper falls back to `players.first`;
+  on a friend screen it would attribute an untagged seat to the friend and
+  fabricate a rivalry. Require both `firebaseId`s explicitly, on distinct seats.
+- **Order by `timeOfDeath`, not `placement`.** `placement` is recomputed as
+  `totalPlayers − eliminated` and player revives can make two seats share a
+  placement (`player_repository.dart:146,156`). `timeOfDeath` is strictly ordered
+  epoch millis; the winner gets one at game end (`player_repository.dart:66`).
+- **Detect wins via `GameModel.winnerId`** (holds the winning `Player.id`).
+- **Read `placement`/`timeOfDeath` defensively.** Both are throwing getters
+  (`_value!`, guarded on `isEliminated`). Read through a try/catch accessor;
+  drop any shared-game candidate whose two seats don't both yield a
+  `timeOfDeath`. One malformed legacy doc must not throw the whole screen.
+- **Per-clock lethality, per-player volume.** A 21-damage kill is
+  `damages.any(d.amount >= 21)` on a *single* clock (Partner clocks don't stack).
+  Total damage *volume* sums `commander` + `partner`. `opponents` is looked up by
+  the dealing seat's per-game `id`; skip the seeded self-entry implicitly by
+  always looking up the *other* seat's id.
+- **Survival fraction normalizes against wall-clock**, `(timeOfDeath −
+  startTime) / (endTime − startTime)`, clamped [0,1] — **not** `durationInSeconds`,
+  which is the pausable game timer and can undercount.
+
+## The stats (v1)
+
+Hero tile on top; the rest in a 3-column `StatsGrid`. Gating uses the existing
+`Need N+ games` copy; damage tiles hide entirely rather than show `0–0`.
+
+| Tile | Value | Min to show |
+|---|---|---|
+| **The Ledger** *(hero)* | Pods you finished ahead vs behind — `7–4` | 3 pods |
+| **Pods Won** | `You 3 · Them 2 · Table 6`, subtitle "even split ≈ 2.8 each" | 3 pods |
+| **Time Alive** | Mean survival fraction, you vs them (`71% · 54%`) | 5 pods |
+| **Final Two** | Times you two were the last standing (`4 of 11`) | 5 pods |
+| **The Beatdown** | Commander damage traded (`Dealt 63 · Taken 19`) | total flow ≥ 21 |
+| **21s** | 21-damage commander kills each way | ≥ 1 occurrence |
+| **Their Go-To** | Their most-played commander at your table (+ art) | 3 pods |
+| **Pods Together** | Shared pod count + first date | 1 pod |
+
+**Cut from v1** (per consult): Focus Fire (targeting bias — too sparse/needs an
+explained baseline) and Pod Length (a property of the pod, not the pair).
+
+**Empty state** (0 shared pods): explain that you can tag this friend into past
+games from a match's detail page — closing the loop with backfill discovery.
+
+## Backfill — per-game seat assignment (user's chosen approach)
+
+Generalize the match-details seat control. Today each non-owned seat shows a
+"claim as me" button; tapping assigns *my* id to that seat and strips it from
+others, writing to my own history copy via `updateGameStats`.
+
+Generalize to an assignment sheet — **Me / <each friend> / Unassign** — backed by
+a new event:
+
+```dart
+AssignSeatIdentity({
+  required GameModel game,
+  required Player seat,
+  required String? assignedFirebaseId, // identity for the seat (null = unassign)
+  required String ownerUserId,         // whose history copy we write to (= me)
+})
+```
+
+Bloc logic (subsumes the old event): set `seat.firebaseId = assignedFirebaseId`;
+if non-null, strip that same id from any *other* seat (one seat per identity);
+write `updateGameStats(game: updated, playerId: ownerUserId)`. `ownerUserId` is
+**always the current user** — tagging a friend edits *my* private copy only; the
+friend sees nothing, so no consent is required. The friends offered come from
+`watchFriends(myId)`.
+
+While here, fix the pre-existing bug where `MatchStandingsWidget` is passed
+`currentUserFirebaseId: game.hostId` — the "You" marker should key off the
+signed-in user, and friend-tagged seats should render distinctly.
+
+## Entry point & routing
+
+- `FriendCard` gains an optional `onTap`; the friends list wires it to push
+  `FriendStatsPage`.
+- Route `/friend_stats_page/:friendId` (following the `MatchDetailsPage` idiom:
+  `routeName`, `routePath`, `path({friendId})`). The `FriendModel` is passed via
+  GoRouter `extra` for the header; stats compute from `friendId` +
+  `MatchHistoryBloc`, so the page still functions if `extra` is absent.
+
+## Copy / localization
+
+New user-facing strings on this screen use inline English constants, consistent
+with the existing stats tooltips (`stats_overview.dart`) and the already-inline
+`No data available` / `No friends found` strings in this area. Localization keys
+are deferred (app supports en/es; the existing stats screen is already partially
+hardcoded). Noted as follow-up, not a v1 blocker.
+
+## Testing
+
+- **Calculator unit tests** (the correctness core): shared-pod filter (both ids
+  required, distinct seats, unparseable dropped), `timeOfDeath` ordering, wins via
+  `winnerId`, survival-fraction normalization + clamp, per-clock 21s vs volume,
+  Final Two, Their Go-To modal selection, expected-wins sum, empty/edge inputs.
+- **Bloc tests**: compile → loaded; failure path.
+- **`MatchDetailsBloc` tests**: `AssignSeatIdentity` for me / friend / unassign,
+  and the one-seat-per-identity strip.
+- **Widget tests**: friend page renders tiles + gating + empty state; friends
+  list tap navigates; assignment sheet lists Me + friends and dispatches.
+
+## Accepted v1 limitations (documented)
+
+- Concessions look like deaths (no concession data) — an early scooper reads as
+  "beaten" in the Ledger.
+- Commander damage is archetype-sparse — Beatdown/21s no-show for combo/
+  spellslinger pairs (by design; gated, not shown as zeros).
+- "Who killed you most" — the best Commander pairwise stat — needs a `killedBy`
+  field that doesn't exist yet. Top of the future-work wishlist in the consult
+  note.
+- Existing global stat `timesKilledByCommander` over-reports by summing both
+  Partner clocks (`stats_overview_bloc.dart:506`). Out of scope here; flagged for
+  a separate fix so the pattern isn't copied.
+```

--- a/lib/app/app_router/app_router.dart
+++ b/lib/app/app_router/app_router.dart
@@ -4,6 +4,7 @@ import 'package:magic_yeti/app/app_router/app_route.dart';
 import 'package:magic_yeti/app/app_router/go_router_refresh_stream.dart';
 import 'package:magic_yeti/app/bloc/app_bloc.dart';
 import 'package:magic_yeti/friends_list/blocked_users/view/blocked_users_page.dart';
+import 'package:magic_yeti/friends_list/friend_stats/view/friend_stats_page.dart';
 import 'package:magic_yeti/friends_list/friends_list_page.dart';
 import 'package:magic_yeti/friends_list/requests/friend_request_page.dart';
 import 'package:magic_yeti/friends_list/search_user/search_user_page.dart';
@@ -92,6 +93,14 @@ class AppRouter {
           pageBuilder: (context, state) => NoTransitionPage(
             name: FriendRequestsPage.routeName,
             child: FriendRequestsPage.pageBuilder(context, state),
+          ),
+        ),
+        AppRoute(
+          name: FriendStatsPage.routeName,
+          path: FriendStatsPage.routePath,
+          pageBuilder: (context, state) => NoTransitionPage(
+            name: FriendStatsPage.routeName,
+            child: FriendStatsPage.pageBuilder(context, state),
           ),
         ),
         AppRoute(

--- a/lib/friends_list/friend_stats/friend_head_to_head.dart
+++ b/lib/friends_list/friend_stats/friend_head_to_head.dart
@@ -1,0 +1,156 @@
+import 'package:equatable/equatable.dart';
+
+/// Aggregated head-to-head statistics between the signed-in user and one
+/// friend, computed over the pods the two of them have shared.
+///
+/// Every field is a raw count or a simple average — never a percentage. At the
+/// small samples this screen operates on (a friend pair may have 3–15 shared
+/// pods ever), counts are honest where rates would imply precision that isn't
+/// there. See the design note for the reasoning:
+/// docs/superpowers/specs/2026-07-17-friend-head-to-head-stats-design.md
+class FriendHeadToHead extends Equatable {
+  const FriendHeadToHead({
+    required this.sharedPods,
+    required this.firstPlayedTogether,
+    required this.youFinishedAhead,
+    required this.theyFinishedAhead,
+    required this.youWon,
+    required this.theyWon,
+    required this.fieldWon,
+    required this.expectedWinsEach,
+    required this.yourAvgSurvival,
+    required this.theirAvgSurvival,
+    required this.finalTwoCount,
+    required this.commanderDamageDealt,
+    required this.commanderDamageTaken,
+    required this.lethalBlowsLanded,
+    required this.lethalBlowsTaken,
+    required this.theirTopCommanderName,
+    required this.theirTopCommanderImageUrl,
+    required this.theirTopCommanderCount,
+  });
+
+  /// The zero-state: no shared pods, nothing to show.
+  static const empty = FriendHeadToHead(
+    sharedPods: 0,
+    firstPlayedTogether: null,
+    youFinishedAhead: 0,
+    theyFinishedAhead: 0,
+    youWon: 0,
+    theyWon: 0,
+    fieldWon: 0,
+    expectedWinsEach: 0,
+    yourAvgSurvival: null,
+    theirAvgSurvival: null,
+    finalTwoCount: 0,
+    commanderDamageDealt: 0,
+    commanderDamageTaken: 0,
+    lethalBlowsLanded: 0,
+    lethalBlowsTaken: 0,
+    theirTopCommanderName: null,
+    theirTopCommanderImageUrl: null,
+    theirTopCommanderCount: 0,
+  );
+
+  /// Number of pods both accounts played in together.
+  final int sharedPods;
+
+  /// Start time of the earliest shared pod, or null if there are none.
+  final DateTime? firstPlayedTogether;
+
+  /// Pods where you outlasted the friend (finished ahead by time of death).
+  final int youFinishedAhead;
+
+  /// Pods where the friend outlasted you.
+  final int theyFinishedAhead;
+
+  /// Pods you won.
+  final int youWon;
+
+  /// Pods the friend won.
+  final int theyWon;
+
+  /// Pods won by someone other than the two of you.
+  final int fieldWon;
+
+  /// Expected wins for one player if every shared pod were a coin flip against
+  /// its own pod size — i.e. the sum of `1 / podSize`. Used to contextualise
+  /// [youWon]/[theyWon] against the multiplayer baseline (25% in a 4-pod).
+  final double expectedWinsEach;
+
+  /// Mean fraction of the pod's wall-clock window you survived (0..1), or null
+  /// if there are no shared pods.
+  final double? yourAvgSurvival;
+
+  /// Mean fraction of the pod's wall-clock window the friend survived (0..1).
+  final double? theirAvgSurvival;
+
+  /// Pods where the two of you were the last two standing.
+  final int finalTwoCount;
+
+  /// Total commander-damage volume you dealt to the friend across shared pods
+  /// (both commander and partner clocks summed).
+  final int commanderDamageDealt;
+
+  /// Total commander-damage volume the friend dealt to you.
+  final int commanderDamageTaken;
+
+  /// Shared pods where a single one of your clocks put 21+ into the friend.
+  final int lethalBlowsLanded;
+
+  /// Shared pods where a single one of the friend's clocks put 21+ into you.
+  final int lethalBlowsTaken;
+
+  /// The friend's most-played commander name across shared pods, or null.
+  final String? theirTopCommanderName;
+
+  /// Art for [theirTopCommanderName], if available.
+  final String? theirTopCommanderImageUrl;
+
+  /// How many shared pods the friend brought [theirTopCommanderName].
+  final int theirTopCommanderCount;
+
+  /// The Ledger and Pods Won need a real sample before a count reads as a
+  /// pattern rather than the match list with extra steps.
+  bool get hasEnoughForLedger => sharedPods >= 3;
+
+  /// Time Alive is a mean; below 5 pods an average is too jumpy to show.
+  bool get hasEnoughForSurvival => sharedPods >= 5;
+
+  /// Final Two has a ~1/6 baseline; below 5 pods one occurrence looks like a
+  /// trend.
+  bool get hasEnoughForFinalTwo => sharedPods >= 5;
+
+  /// Their Go-To needs a modal commander to exist.
+  bool get hasEnoughForTopCommander =>
+      sharedPods >= 3 && theirTopCommanderName != null;
+
+  /// Commander damage is archetype-sparse; hide the trade entirely below one
+  /// clock's worth of total flow rather than showing a rivalry of zeroes.
+  bool get hasBeatdown => (commanderDamageDealt + commanderDamageTaken) >= 21;
+
+  /// Only surface 21s when at least one actually happened.
+  bool get hasLethalBlows => (lethalBlowsLanded + lethalBlowsTaken) >= 1;
+
+  @override
+  List<Object?> get props => [
+    sharedPods,
+    firstPlayedTogether,
+    youFinishedAhead,
+    theyFinishedAhead,
+    youWon,
+    theyWon,
+    fieldWon,
+    expectedWinsEach,
+    yourAvgSurvival,
+    theirAvgSurvival,
+    finalTwoCount,
+    commanderDamageDealt,
+    commanderDamageTaken,
+    lethalBlowsLanded,
+    lethalBlowsTaken,
+    theirTopCommanderName,
+    theirTopCommanderImageUrl,
+    theirTopCommanderCount,
+  ];
+}

--- a/lib/friends_list/friend_stats/friend_head_to_head_calculator.dart
+++ b/lib/friends_list/friend_stats/friend_head_to_head_calculator.dart
@@ -1,0 +1,240 @@
+import 'package:firebase_database_repository/firebase_database_repository.dart';
+import 'package:magic_yeti/friends_list/friend_stats/friend_head_to_head.dart';
+import 'package:player_repository/player_repository.dart';
+
+/// Computes [FriendHeadToHead] from the signed-in user's own match history.
+///
+/// This reads only the user's own games (which already contain every
+/// participant's seat via the game fan-out), so no cross-account reads are
+/// needed. It is a pure function of its inputs — no I/O — so the correctness
+/// rules below can be exercised directly in unit tests.
+///
+/// Correctness rules (each verified against the game/player models):
+/// - A pod counts only when one seat's `firebaseId` is `myId` and a *different*
+///   seat's is `friendId`. There is no "nearest seat" fallback — an untagged
+///   seat is never attributed to either player.
+/// - Finish order comes from `timeOfDeath` (strictly ordered epoch millis; the
+///   winner is stamped at game end), never `placement`, which can collide when
+///   a player is revived.
+/// - Wins come from [GameModel.winnerId].
+/// - `timeOfDeath` is a throwing getter; it is read through [_timeOfDeath],
+///   and a pod whose two seats don't both yield one is dropped.
+/// - A 21-damage kill is a single clock reaching 21 (`any`), while damage
+///   *volume* sums both clocks (`fold`) — different questions.
+/// - Survival fraction normalises against the wall-clock window
+///   (`endTime - startTime`), not the pausable `durationInSeconds`.
+class FriendHeadToHeadCalculator {
+  const FriendHeadToHeadCalculator._();
+
+  static FriendHeadToHead compute({
+    required List<GameModel> games,
+    required String myId,
+    required String friendId,
+  }) {
+    if (myId.isEmpty || friendId.isEmpty || myId == friendId) {
+      return FriendHeadToHead.empty;
+    }
+
+    var sharedPods = 0;
+    DateTime? firstPlayed;
+    var youAhead = 0;
+    var theyAhead = 0;
+    var youWon = 0;
+    var theyWon = 0;
+    var fieldWon = 0;
+    var expectedWins = 0.0;
+    var finalTwo = 0;
+    var dmgDealt = 0;
+    var dmgTaken = 0;
+    var lethalLanded = 0;
+    var lethalTaken = 0;
+    final survivalYou = <double>[];
+    final survivalThem = <double>[];
+    final commanderCounts = <String, int>{};
+    final commanderReps = <String, Commander>{};
+
+    for (final game in games) {
+      final me = _seatFor(game, myId);
+      final friend = _seatFor(game, friendId);
+      if (me == null || friend == null || me.id == friend.id) continue;
+
+      final myTod = _timeOfDeath(me);
+      final friendTod = _timeOfDeath(friend);
+      if (myTod == null || friendTod == null) continue;
+
+      sharedPods++;
+      if (firstPlayed == null || game.startTime.isBefore(firstPlayed)) {
+        firstPlayed = game.startTime;
+      }
+
+      // The Ledger.
+      if (myTod > friendTod) {
+        youAhead++;
+      } else if (friendTod > myTod) {
+        theyAhead++;
+      }
+
+      // Pods Won.
+      if (game.winnerId == me.id) {
+        youWon++;
+      } else if (game.winnerId == friend.id) {
+        theyWon++;
+      } else {
+        fieldWon++;
+      }
+      final podSize = game.players.length;
+      if (podSize > 0) expectedWins += 1 / podSize;
+
+      // Time Alive.
+      final myFraction = _survivalFraction(game, myTod);
+      final friendFraction = _survivalFraction(game, friendTod);
+      if (myFraction != null) survivalYou.add(myFraction);
+      if (friendFraction != null) survivalThem.add(friendFraction);
+
+      // Final Two.
+      if (_areFinalTwo(game, me.id, friend.id)) finalTwo++;
+
+      // The Beatdown (volume, both clocks) — friend took from me, I took from
+      // friend.
+      dmgDealt += _damageVolume(victim: friend, dealerId: me.id);
+      dmgTaken += _damageVolume(victim: me, dealerId: friend.id);
+
+      // 21s (single clock lethality).
+      if (_landedLethalClock(victim: friend, dealerId: me.id)) lethalLanded++;
+      if (_landedLethalClock(victim: me, dealerId: friend.id)) lethalTaken++;
+
+      // Their Go-To.
+      final commander = friend.commander;
+      if (commander != null) {
+        final key = commander.oracleId ?? commander.name;
+        commanderCounts[key] = (commanderCounts[key] ?? 0) + 1;
+        commanderReps[key] = commander;
+      }
+    }
+
+    if (sharedPods == 0) return FriendHeadToHead.empty;
+
+    final topCommander = _topCommander(commanderCounts, commanderReps);
+
+    return FriendHeadToHead(
+      sharedPods: sharedPods,
+      firstPlayedTogether: firstPlayed,
+      youFinishedAhead: youAhead,
+      theyFinishedAhead: theyAhead,
+      youWon: youWon,
+      theyWon: theyWon,
+      fieldWon: fieldWon,
+      expectedWinsEach: expectedWins,
+      yourAvgSurvival: _average(survivalYou),
+      theirAvgSurvival: _average(survivalThem),
+      finalTwoCount: finalTwo,
+      commanderDamageDealt: dmgDealt,
+      commanderDamageTaken: dmgTaken,
+      lethalBlowsLanded: lethalLanded,
+      lethalBlowsTaken: lethalTaken,
+      theirTopCommanderName: topCommander?.name,
+      theirTopCommanderImageUrl: topCommander?.imageUrl,
+      theirTopCommanderCount: topCommander == null
+          ? 0
+          : commanderCounts[topCommander.key]!,
+    );
+  }
+
+  /// First seat whose account link is [firebaseId], or null.
+  static Player? _seatFor(GameModel game, String firebaseId) {
+    for (final p in game.players) {
+      if (p.firebaseId == firebaseId) return p;
+    }
+    return null;
+  }
+
+  /// Reads a seat's time of death without throwing. Returns null for an active
+  /// or malformed seat.
+  static int? _timeOfDeath(Player p) {
+    if (!p.isEliminated) return null;
+    try {
+      return p.timeOfDeath;
+    } on Object catch (_) {
+      // A malformed legacy seat (eliminated but no recorded death) throws.
+      return null;
+    }
+  }
+
+  static double? _survivalFraction(GameModel game, int timeOfDeath) {
+    final start = game.startTime.millisecondsSinceEpoch;
+    final end = game.endTime.millisecondsSinceEpoch;
+    final span = end - start;
+    if (span <= 0) return null;
+    return ((timeOfDeath - start) / span).clamp(0.0, 1.0);
+  }
+
+  /// Whether [aId] and [bId] hold the two latest deaths in the pod.
+  static bool _areFinalTwo(GameModel game, String aId, String bId) {
+    final ordered = <MapEntry<String, int>>[];
+    for (final p in game.players) {
+      final tod = _timeOfDeath(p);
+      if (tod != null) ordered.add(MapEntry(p.id, tod));
+    }
+    if (ordered.length < 2) return false;
+    ordered.sort((x, y) => y.value.compareTo(x.value));
+    final topTwo = {ordered[0].key, ordered[1].key};
+    return topTwo.contains(aId) && topTwo.contains(bId);
+  }
+
+  static int _damageVolume({required Player victim, required String dealerId}) {
+    final entry = _opponentEntry(victim, dealerId);
+    if (entry == null) return 0;
+    return entry.damages.fold<int>(0, (sum, d) => sum + d.amount);
+  }
+
+  static bool _landedLethalClock({
+    required Player victim,
+    required String dealerId,
+  }) {
+    final entry = _opponentEntry(victim, dealerId);
+    if (entry == null) return false;
+    return entry.damages.any((d) => d.amount >= 21);
+  }
+
+  static Opponent? _opponentEntry(Player victim, String dealerId) {
+    final opponents = victim.opponents;
+    if (opponents == null) return null;
+    for (final o in opponents) {
+      if (o.playerId == dealerId) return o;
+    }
+    return null;
+  }
+
+  static double? _average(List<double> values) {
+    if (values.isEmpty) return null;
+    return values.reduce((a, b) => a + b) / values.length;
+  }
+
+  static _TopCommander? _topCommander(
+    Map<String, int> counts,
+    Map<String, Commander> reps,
+  ) {
+    if (counts.isEmpty) return null;
+    String? bestKey;
+    var bestCount = -1;
+    for (final entry in counts.entries) {
+      final count = entry.value;
+      // Deterministic tie-break: higher count wins, then commander name.
+      if (count > bestCount ||
+          (count == bestCount &&
+              reps[entry.key]!.name.compareTo(reps[bestKey]!.name) < 0)) {
+        bestKey = entry.key;
+        bestCount = count;
+      }
+    }
+    final rep = reps[bestKey]!;
+    return _TopCommander(bestKey!, rep.name, rep.imageUrl);
+  }
+}
+
+class _TopCommander {
+  const _TopCommander(this.key, this.name, this.imageUrl);
+  final String key;
+  final String name;
+  final String imageUrl;
+}

--- a/lib/friends_list/friend_stats/friend_stats.dart
+++ b/lib/friends_list/friend_stats/friend_stats.dart
@@ -1,0 +1,3 @@
+export 'friend_head_to_head.dart';
+export 'friend_head_to_head_calculator.dart';
+export 'friend_stats_bloc.dart';

--- a/lib/friends_list/friend_stats/friend_stats_bloc.dart
+++ b/lib/friends_list/friend_stats/friend_stats_bloc.dart
@@ -1,0 +1,35 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:firebase_database_repository/firebase_database_repository.dart';
+import 'package:magic_yeti/friends_list/friend_stats/friend_head_to_head.dart';
+import 'package:magic_yeti/friends_list/friend_stats/friend_head_to_head_calculator.dart';
+
+part 'friend_stats_event.dart';
+part 'friend_stats_state.dart';
+
+/// Computes head-to-head stats between the signed-in user and one friend from
+/// the user's own match history.
+///
+/// Games are injected via [CompileFriendStats] rather than fetched here — the
+/// friend page feeds them in from the app-wide match-history stream, mirroring
+/// how the stats overview is driven. Computation is synchronous and cheap, so
+/// no generation fence is needed.
+class FriendStatsBloc extends Bloc<FriendStatsEvent, FriendStatsState> {
+  FriendStatsBloc() : super(FriendStatsInitial()) {
+    on<CompileFriendStats>(_onCompile);
+  }
+
+  void _onCompile(CompileFriendStats event, Emitter<FriendStatsState> emit) {
+    emit(FriendStatsLoading());
+    try {
+      final stats = FriendHeadToHeadCalculator.compute(
+        games: event.games,
+        myId: event.myId,
+        friendId: event.friendId,
+      );
+      emit(FriendStatsLoaded(stats));
+    } on Object catch (error) {
+      emit(FriendStatsFailure(error.toString()));
+    }
+  }
+}

--- a/lib/friends_list/friend_stats/friend_stats_event.dart
+++ b/lib/friends_list/friend_stats/friend_stats_event.dart
@@ -1,0 +1,24 @@
+part of 'friend_stats_bloc.dart';
+
+sealed class FriendStatsEvent extends Equatable {
+  const FriendStatsEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Recompute head-to-head stats for [friendId] from the user's [games].
+final class CompileFriendStats extends FriendStatsEvent {
+  const CompileFriendStats({
+    required this.myId,
+    required this.friendId,
+    required this.games,
+  });
+
+  final String myId;
+  final String friendId;
+  final List<GameModel> games;
+
+  @override
+  List<Object?> get props => [myId, friendId, games];
+}

--- a/lib/friends_list/friend_stats/friend_stats_state.dart
+++ b/lib/friends_list/friend_stats/friend_stats_state.dart
@@ -1,0 +1,30 @@
+part of 'friend_stats_bloc.dart';
+
+sealed class FriendStatsState extends Equatable {
+  const FriendStatsState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+final class FriendStatsInitial extends FriendStatsState {}
+
+final class FriendStatsLoading extends FriendStatsState {}
+
+final class FriendStatsLoaded extends FriendStatsState {
+  const FriendStatsLoaded(this.stats);
+
+  final FriendHeadToHead stats;
+
+  @override
+  List<Object?> get props => [stats];
+}
+
+final class FriendStatsFailure extends FriendStatsState {
+  const FriendStatsFailure(this.message);
+
+  final String message;
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/friends_list/friend_stats/view/friend_stats_page.dart
+++ b/lib/friends_list/friend_stats/view/friend_stats_page.dart
@@ -1,0 +1,258 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:firebase_database_repository/firebase_database_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:magic_yeti/app/bloc/app_bloc.dart';
+import 'package:magic_yeti/friends_list/friend_stats/friend_stats.dart';
+import 'package:magic_yeti/friends_list/friend_stats/view/friend_stats_tiles.dart';
+import 'package:magic_yeti/home/match_history_bloc/match_history_bloc.dart';
+import 'package:magic_yeti/stats_overview/widgets/stats_overview_skeleton.dart';
+
+/// Head-to-head stats between the signed-in user and one friend, over the pods
+/// they have played together.
+///
+/// Reached by tapping a friend in the friends list. The [FriendModel] is passed
+/// via GoRouter `extra` for the header; stats are computed from [friendId] and
+/// the app-wide match history, so the page still renders if `extra` is absent.
+class FriendStatsPage extends StatelessWidget {
+  const FriendStatsPage({
+    required this.friendId,
+    this.friend,
+    super.key,
+  });
+
+  factory FriendStatsPage.pageBuilder(_, GoRouterState state) {
+    return FriendStatsPage(
+      friendId: state.pathParameters['friendId']!,
+      friend: state.extra is FriendModel ? state.extra! as FriendModel : null,
+    );
+  }
+
+  final String friendId;
+  final FriendModel? friend;
+
+  static const routeName = 'friend_stats_page';
+  static String get routePath => '/friend_stats_page/:friendId';
+  static String path({required String friendId}) =>
+      '/friend_stats_page/$friendId';
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => FriendStatsBloc(),
+      child: _FriendStatsView(friendId: friendId, friend: friend),
+    );
+  }
+}
+
+class _FriendStatsView extends StatefulWidget {
+  const _FriendStatsView({required this.friendId, this.friend});
+
+  final String friendId;
+  final FriendModel? friend;
+
+  @override
+  State<_FriendStatsView> createState() => _FriendStatsViewState();
+}
+
+class _FriendStatsViewState extends State<_FriendStatsView> {
+  @override
+  void initState() {
+    super.initState();
+    final matchHistory = context.read<MatchHistoryBloc>().state;
+    if (matchHistory.status == MatchHistoryStatus.loadingHistorySuccess ||
+        matchHistory.status == MatchHistoryStatus.gameNotFound) {
+      _compile(matchHistory.games);
+    }
+  }
+
+  void _compile(List<GameModel> games) {
+    context.read<FriendStatsBloc>().add(
+      CompileFriendStats(
+        myId: context.read<AppBloc>().state.user.id,
+        friendId: widget.friendId,
+        games: games,
+      ),
+    );
+  }
+
+  String get _friendName => widget.friend?.username ?? 'Friend';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.pop(),
+        ),
+        title: Text('$_friendName · Head to Head'),
+      ),
+      body: BlocListener<MatchHistoryBloc, MatchHistoryState>(
+        listenWhen: (previous, current) =>
+            !identical(previous.games, current.games),
+        listener: (context, state) => _compile(state.games),
+        child: BlocBuilder<FriendStatsBloc, FriendStatsState>(
+          builder: (context, state) {
+            return switch (state) {
+              FriendStatsLoaded(:final stats) => _FriendStatsBody(
+                friendName: _friendName,
+                friend: widget.friend,
+                stats: stats,
+              ),
+              FriendStatsFailure() => const Center(
+                child: Text('Could not load these stats.'),
+              ),
+              _ => const StatsOverviewSkeleton(itemCount: 6),
+            };
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _FriendStatsBody extends StatelessWidget {
+  const _FriendStatsBody({
+    required this.friendName,
+    required this.friend,
+    required this.stats,
+  });
+
+  final String friendName;
+  final FriendModel? friend;
+  final FriendHeadToHead stats;
+
+  @override
+  Widget build(BuildContext context) {
+    if (stats.sharedPods == 0) {
+      return _EmptyState(friendName: friendName);
+    }
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _Header(friendName: friendName, friend: friend, stats: stats),
+          const SizedBox(height: 16),
+          LedgerHeroTile(stats: stats, friendName: friendName),
+          const SizedBox(height: 16),
+          // The grid is intrinsically sized inside a scroll view.
+          GridView.count(
+            crossAxisCount: 3,
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            crossAxisSpacing: 24,
+            mainAxisSpacing: 16,
+            childAspectRatio: 0.85,
+            children: buildFriendStatTiles(stats),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({
+    required this.friendName,
+    required this.friend,
+    required this.stats,
+  });
+
+  final String friendName;
+  final FriendModel? friend;
+  final FriendHeadToHead stats;
+
+  @override
+  Widget build(BuildContext context) {
+    final imageUrl = friend?.profilePictureUrl ?? '';
+    final since = stats.firstPlayedTogether;
+    final subtitle = since == null
+        ? '${stats.sharedPods} pods together'
+        : '${stats.sharedPods} pods together · since '
+              '${DateFormat('MMM yyyy').format(since)}';
+
+    return Row(
+      children: [
+        CircleAvatar(
+          radius: 28,
+          backgroundColor: AppColors.tertiary,
+          backgroundImage: imageUrl.isNotEmpty ? NetworkImage(imageUrl) : null,
+          child: imageUrl.isEmpty
+              ? Text(
+                  friendName.isNotEmpty ? friendName[0].toUpperCase() : '?',
+                  style: const TextStyle(
+                    color: AppColors.white,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 22,
+                  ),
+                )
+              : null,
+        ),
+        const SizedBox(width: 14),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                friendName,
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              Text(
+                subtitle,
+                style: Theme.of(
+                  context,
+                ).textTheme.bodyMedium?.copyWith(color: AppColors.neutral60),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.friendName});
+
+  final String friendName;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(
+              Icons.groups_outlined,
+              size: 64,
+              color: AppColors.tertiary,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'No shared pods yet',
+              style: Theme.of(context).textTheme.titleLarge,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              "Once you and $friendName play a pod together it'll show up "
+              'here. Played before adding each other? Open a match from your '
+              'history and tag $friendName into their seat.',
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium?.copyWith(color: AppColors.neutral60),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/friends_list/friend_stats/view/friend_stats_tiles.dart
+++ b/lib/friends_list/friend_stats/view/friend_stats_tiles.dart
@@ -1,0 +1,130 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:magic_yeti/friends_list/friend_stats/friend_head_to_head.dart';
+import 'package:magic_yeti/stats_overview/widgets/stats_widget.dart';
+
+/// The hero tile: a pairwise finish record. This is the one stat with both a
+/// real sample and a real story at ~10 pods — "who finishes ahead" is defined
+/// in every shared pod with a true 50% baseline, unlike a 25%-event win rate.
+class LedgerHeroTile extends StatelessWidget {
+  const LedgerHeroTile({
+    required this.stats,
+    required this.friendName,
+    super.key,
+  });
+
+  final FriendHeadToHead stats;
+  final String friendName;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final enough = stats.hasEnoughForLedger;
+
+    return Card(
+      color: AppColors.surface,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+        child: Column(
+          children: [
+            Text(
+              'The Ledger',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: AppColors.secondary,
+              ),
+            ),
+            const SizedBox(height: 8),
+            if (enough) ...[
+              Text(
+                '${stats.youFinishedAhead}–${stats.theyFinishedAhead}',
+                style: theme.textTheme.displaySmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'you finish ahead in ${stats.youFinishedAhead} '
+                'of ${stats.sharedPods} pods',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: AppColors.neutral60,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ] else
+              Text(
+                'Need 3+ pods together',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: AppColors.neutral60,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Builds the secondary stat tiles for the grid, applying each stat's sample
+/// gate. Damage tiles (The Beatdown, 21s) are omitted entirely below their
+/// gates rather than shown as a rivalry of zeroes.
+List<Widget> buildFriendStatTiles(FriendHeadToHead stats) {
+  int pct(double? f) => ((f ?? 0) * 100).round();
+
+  return [
+    StatsWidget(
+      title: 'Pods Won',
+      stat: stats.hasEnoughForLedger
+          ? '${stats.youWon}·${stats.theyWon}·${stats.fieldWon}'
+          : 'Need 3+',
+      tooltip:
+          'You · Them · Rest of the table, across ${stats.sharedPods} '
+          'pods. An even split would be about '
+          '${stats.expectedWinsEach.toStringAsFixed(1)} each — in a 4-player '
+          'pod the baseline is 25%, not 50%.',
+    ),
+    StatsWidget(
+      title: 'Their Go-To',
+      stat: stats.hasEnoughForTopCommander
+          ? (stats.theirTopCommanderName ?? 'Need 3+')
+          : 'Need 3+',
+      tooltip: stats.hasEnoughForTopCommander
+          ? 'The commander they bring to your table most often '
+                '(${stats.theirTopCommanderCount} of ${stats.sharedPods} pods).'
+          : 'Their most-played commander at your table (needs 3+ pods).',
+    ),
+    StatsWidget(
+      title: 'Time Alive',
+      stat: stats.hasEnoughForSurvival
+          ? '${pct(stats.yourAvgSurvival)}% / ${pct(stats.theirAvgSurvival)}%'
+          : 'Need 5+',
+      tooltip:
+          'Average share of the pod each of you survives — you / them. '
+          'The Ledger says who outlasts whom; this says by how much.',
+    ),
+    StatsWidget(
+      title: 'Final Two',
+      stat: stats.hasEnoughForFinalTwo
+          ? '${stats.finalTwoCount} of ${stats.sharedPods}'
+          : 'Need 5+',
+      tooltip:
+          'Pods where the two of you were the last players standing — '
+          'the mark of a real rivalry.',
+    ),
+    if (stats.hasBeatdown)
+      StatsWidget(
+        title: 'The Beatdown',
+        stat: '${stats.commanderDamageDealt} / ${stats.commanderDamageTaken}',
+        tooltip:
+            'Total commander damage you have dealt to them / taken from '
+            'them across your shared pods.',
+      ),
+    if (stats.hasLethalBlows)
+      StatsWidget(
+        title: '21s',
+        stat: '${stats.lethalBlowsLanded} / ${stats.lethalBlowsTaken}',
+        tooltip:
+            'Pods where a single commander landed the lethal 21 — you on '
+            'them / them on you.',
+      ),
+  ];
+}

--- a/lib/friends_list/friends_list/friends_list.dart
+++ b/lib/friends_list/friends_list/friends_list.dart
@@ -4,7 +4,9 @@ import 'package:app_ui/app_ui.dart';
 import 'package:firebase_database_repository/firebase_database_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:magic_yeti/app/bloc/app_bloc.dart';
+import 'package:magic_yeti/friends_list/friend_stats/view/friend_stats_page.dart';
 import 'package:magic_yeti/friends_list/friends_list/bloc/friend_list_bloc.dart';
 import 'package:magic_yeti/friends_list/widgets/friend_card.dart';
 import 'package:magic_yeti/l10n/arb/app_localizations.dart';
@@ -53,11 +55,13 @@ class FriendsListView extends StatelessWidget {
             itemBuilder: (context, index) {
               final friend = state.friends[index];
               return FriendCard(
-                initial: friend.username.isNotEmpty
-                    ? friend.username[0]
-                    : '?',
+                initial: friend.username.isNotEmpty ? friend.username[0] : '?',
                 title: friend.username,
                 subtitle: friend.friendCode,
+                onTap: () => context.push(
+                  FriendStatsPage.path(friendId: friend.userId),
+                  extra: friend,
+                ),
                 trailing: PopupMenuButton<_FriendCardAction>(
                   icon: const Icon(
                     Icons.more_vert,
@@ -137,9 +141,9 @@ class FriendsListView extends StatelessWidget {
                   style: const TextStyle(color: AppColors.red),
                 ),
                 onPressed: () {
-                  context
-                      .read<FriendBloc>()
-                      .add(RemoveFriend(userId, friend.userId));
+                  context.read<FriendBloc>().add(
+                    RemoveFriend(userId, friend.userId),
+                  );
                   Navigator.of(dialogContext).pop();
                 },
               ),
@@ -185,16 +189,16 @@ class FriendsListView extends StatelessWidget {
                 ),
                 onPressed: () {
                   context.read<FriendBloc>().add(
-                        BlockFriend(
-                          userId,
-                          BlockedUserModel(
-                            userId: friend.userId,
-                            username: friend.username,
-                            imageUrl: friend.profilePictureUrl,
-                            friendCode: friend.friendCode,
-                          ),
-                        ),
-                      );
+                    BlockFriend(
+                      userId,
+                      BlockedUserModel(
+                        userId: friend.userId,
+                        username: friend.username,
+                        imageUrl: friend.profilePictureUrl,
+                        friendCode: friend.friendCode,
+                      ),
+                    ),
+                  );
                   Navigator.of(dialogContext).pop();
                 },
               ),

--- a/lib/friends_list/widgets/friend_card.dart
+++ b/lib/friends_list/widgets/friend_card.dart
@@ -12,6 +12,7 @@ class FriendCard extends StatelessWidget {
     super.key,
     this.subtitle,
     this.trailing,
+    this.onTap,
   });
 
   final String initial;
@@ -19,55 +20,62 @@ class FriendCard extends StatelessWidget {
   final String? subtitle;
   final Widget? trailing;
 
+  /// Tapping the card body (outside [trailing]) invokes this, if provided.
+  final VoidCallback? onTap;
+
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-      child: Container(
-        decoration: BoxDecoration(
-          color: AppColors.surface,
-          borderRadius: BorderRadius.circular(12),
-        ),
-        padding: const EdgeInsets.all(14),
-        child: Row(
-          children: [
-            CircleAvatar(
-              backgroundColor: AppColors.tertiary,
-              child: Text(
-                initial.toUpperCase(),
-                style: const TextStyle(
-                  color: AppColors.white,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 18,
-                ),
-              ),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
+      child: Material(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(12),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.all(14),
+            child: Row(
+              children: [
+                CircleAvatar(
+                  backgroundColor: AppColors.tertiary,
+                  child: Text(
+                    initial.toUpperCase(),
                     style: const TextStyle(
                       color: AppColors.white,
-                      fontWeight: FontWeight.w600,
-                      fontSize: 15,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 18,
                     ),
                   ),
-                  if (subtitle != null)
-                    Text(
-                      subtitle!,
-                      style: const TextStyle(
-                        color: AppColors.neutral60,
-                        fontSize: 12,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: const TextStyle(
+                          color: AppColors.white,
+                          fontWeight: FontWeight.w600,
+                          fontSize: 15,
+                        ),
                       ),
-                    ),
-                ],
-              ),
+                      if (subtitle != null)
+                        Text(
+                          subtitle!,
+                          style: const TextStyle(
+                            color: AppColors.neutral60,
+                            fontSize: 12,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                ?trailing,
+              ],
             ),
-            ?trailing,
-          ],
+          ),
         ),
       ),
     );

--- a/lib/match_details/bloc/match_details_bloc.dart
+++ b/lib/match_details/bloc/match_details_bloc.dart
@@ -9,10 +9,10 @@ part 'match_details_state.dart';
 class MatchDetailsBloc extends Bloc<MatchDetailsEvent, MatchDetailsState> {
   MatchDetailsBloc({
     required FirebaseDatabaseRepository databaseRepository,
-  })  : _databaseRepository = databaseRepository,
-        super(MatchDetailsInitial()) {
+  }) : _databaseRepository = databaseRepository,
+       super(MatchDetailsInitial()) {
     on<DeleteMatchEvent>(_onDeleteMatch);
-    on<UpdatePlayerOwnership>(_onUpdatePlayerOwnership);
+    on<AssignSeatIdentity>(_onAssignSeatIdentity);
   }
 
   final FirebaseDatabaseRepository _databaseRepository;
@@ -29,35 +29,35 @@ class MatchDetailsBloc extends Bloc<MatchDetailsEvent, MatchDetailsState> {
     }
   }
 
-  Future<void> _onUpdatePlayerOwnership(
-    UpdatePlayerOwnership event,
+  Future<void> _onAssignSeatIdentity(
+    AssignSeatIdentity event,
     Emitter<MatchDetailsState> emit,
   ) async {
     try {
-      // Update the players list, removing the Firebase ID from any player that had it
-      // and assigning it to the selected player
+      final assignedId = event.assignedFirebaseId;
+
+      // Place the identity on the chosen seat and strip it from any other seat
+      // that held it, so one account never occupies two seats.
       final updatedPlayers = event.game.players.map((p) {
-        if (p.id == event.player.id) {
-          // Assign the Firebase ID to the selected player
-          return p.copyWith(firebaseId: () => event.currentUserFirebaseId);
-        } else if (p.firebaseId == event.currentUserFirebaseId) {
-          // Remove the Firebase ID from any other player that had it
+        if (p.id == event.seat.id) {
+          return p.copyWith(firebaseId: () => assignedId);
+        }
+        if (assignedId != null && p.firebaseId == assignedId) {
           return p.copyWith(firebaseId: () => null);
         }
         return p;
       }).toList();
 
-      // Update the game model with the new player list
       final updatedGame = event.game.copyWith(players: updatedPlayers);
 
-      // Save the updated game to Firebase
+      // Written to the owner's own history copy only.
       await _databaseRepository.updateGameStats(
         game: updatedGame,
-        playerId: event.currentUserFirebaseId,
+        playerId: event.ownerUserId,
       );
 
       emit(MatchDetailsSuccess());
-    } catch (error) {
+    } on Object catch (error) {
       emit(MatchDetailsError(error.toString()));
     }
   }

--- a/lib/match_details/bloc/match_details_event.dart
+++ b/lib/match_details/bloc/match_details_event.dart
@@ -4,7 +4,7 @@ sealed class MatchDetailsEvent extends Equatable {
   const MatchDetailsEvent();
 
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }
 
 final class DeleteMatchEvent extends MatchDetailsEvent {
@@ -16,18 +16,28 @@ final class DeleteMatchEvent extends MatchDetailsEvent {
   List<Object> get props => [gameId, userId];
 }
 
-/// Event to update player ownership in a game
-final class UpdatePlayerOwnership extends MatchDetailsEvent {
-  const UpdatePlayerOwnership({
+/// Assigns an account identity to a seat in a saved game.
+///
+/// [assignedFirebaseId] is the account to place on [seat] — the signed-in user,
+/// a friend, or null to unassign. Whichever identity is assigned is removed
+/// from any other seat that held it, so one account never occupies two seats.
+///
+/// The edit is written to [ownerUserId]'s own history copy only; tagging a
+/// friend is a private annotation on the user's records that the friend never
+/// sees.
+final class AssignSeatIdentity extends MatchDetailsEvent {
+  const AssignSeatIdentity({
     required this.game,
-    required this.player,
-    required this.currentUserFirebaseId,
+    required this.seat,
+    required this.assignedFirebaseId,
+    required this.ownerUserId,
   });
 
   final GameModel game;
-  final Player player;
-  final String currentUserFirebaseId;
+  final Player seat;
+  final String? assignedFirebaseId;
+  final String ownerUserId;
 
   @override
-  List<Object> get props => [game, player, currentUserFirebaseId];
+  List<Object?> get props => [game, seat, assignedFirebaseId, ownerUserId];
 }

--- a/lib/match_details/view/match_details_page.dart
+++ b/lib/match_details/view/match_details_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:app_ui/app_ui.dart';
 import 'package:firebase_database_repository/firebase_database_repository.dart';
 import 'package:flutter/material.dart';
@@ -102,38 +104,101 @@ class _MatchDetailsContent extends StatelessWidget {
 
   final String gameId;
 
-  void _handlePlayerSelection(BuildContext context, Player player) {
-    final currentUserFirebaseId = context.read<AppBloc>().state.user.id;
+  /// Opens a sheet to assign the tapped [seat] to the signed-in user, a friend,
+  /// or nobody. Tagging a friend edits only the user's own history copy.
+  void _showSeatAssignmentSheet(BuildContext context, Player seat) {
+    final myId = context.read<AppBloc>().state.user.id;
     final game = context.read<MatchHistoryBloc>().state.games.firstWhere(
-          (game) => game.id == gameId,
-        );
-    // Find the currently assigned player, if any
-    final currentPlayer = game.players.firstWhere(
-      (p) => p.firebaseId == currentUserFirebaseId,
-      orElse: () => player,
+      (game) => game.id == gameId,
     );
+    final bloc = context.read<MatchDetailsBloc>();
+    final repository = context.read<FirebaseDatabaseRepository>();
+    final messenger = ScaffoldMessenger.of(context);
 
-    // Dispatch event to update player ownership
-    context.read<MatchDetailsBloc>().add(
-          UpdatePlayerOwnership(
-            game: game,
-            player: player,
-            currentUserFirebaseId: currentUserFirebaseId,
-          ),
-        );
+    unawaited(
+      showModalBottomSheet<void>(
+        context: context,
+        backgroundColor: AppColors.surface,
+        builder: (sheetContext) {
+          void assign(String? firebaseId, String label) {
+            bloc.add(
+              AssignSeatIdentity(
+                game: game,
+                seat: seat,
+                assignedFirebaseId: firebaseId,
+                ownerUserId: myId,
+              ),
+            );
+            Navigator.of(sheetContext).pop();
+            messenger.showSnackBar(
+              SnackBar(
+                content: Text('${seat.name} → $label'),
+                duration: const Duration(seconds: 2),
+              ),
+            );
+          }
 
-    // Show a confirmation snackbar
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: currentPlayer.id != player.id
-            ? Text(
-                context.l10n.changedPlayerMessage(
-                  currentPlayer.name,
-                  player.name,
+          return SafeArea(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      'Who played ${seat.name}?',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  ),
                 ),
-              )
-            : Text(context.l10n.wasPlayerMessage(player.name)),
-        duration: const Duration(seconds: 2),
+                ListTile(
+                  leading: const Icon(Icons.person, color: Colors.blue),
+                  title: const Text('Me'),
+                  trailing: seat.firebaseId == myId
+                      ? const Icon(Icons.check)
+                      : null,
+                  onTap: () => assign(myId, 'You'),
+                ),
+                StreamBuilder<List<FriendModel>>(
+                  stream: repository.watchFriends(myId),
+                  builder: (context, snapshot) {
+                    final friends = snapshot.data ?? const <FriendModel>[];
+                    return Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        for (final friend in friends)
+                          ListTile(
+                            leading: CircleAvatar(
+                              backgroundColor: AppColors.tertiary,
+                              child: Text(
+                                friend.username.isNotEmpty
+                                    ? friend.username[0].toUpperCase()
+                                    : '?',
+                                style: const TextStyle(color: AppColors.white),
+                              ),
+                            ),
+                            title: Text(friend.username),
+                            trailing: seat.firebaseId == friend.userId
+                                ? const Icon(Icons.check)
+                                : null,
+                            onTap: () => assign(friend.userId, friend.username),
+                          ),
+                      ],
+                    );
+                  },
+                ),
+                if (seat.firebaseId != null)
+                  ListTile(
+                    leading: const Icon(Icons.person_off_outlined),
+                    title: const Text('Unassign'),
+                    onTap: () => assign(null, 'unassigned'),
+                  ),
+                const SizedBox(height: 8),
+              ],
+            ),
+          );
+        },
       ),
     );
   }
@@ -185,10 +250,10 @@ class _MatchDetailsContent extends StatelessWidget {
               MatchStandingsWidget(
                 players: game.players,
                 winner: winningPlayer,
-                currentUserFirebaseId: game.hostId,
+                currentUserFirebaseId: context.read<AppBloc>().state.user.id,
                 startingPlayerId: game.startingPlayerId,
                 onSelectPlayer: (player) =>
-                    _handlePlayerSelection(context, player),
+                    _showSeatAssignmentSheet(context, player),
               ),
               const SizedBox(height: 16),
               // Match metadata
@@ -241,8 +306,8 @@ class MatchWinnerWidget extends StatelessWidget {
                   child: CircleAvatar(
                     backgroundImage:
                         winner.commander?.imageUrl.isNotEmpty ?? false
-                            ? NetworkImage(winner.commander!.imageUrl)
-                            : null,
+                        ? NetworkImage(winner.commander!.imageUrl)
+                        : null,
                     backgroundColor: Color(winner.color),
                     radius: 50,
                   ),
@@ -277,10 +342,9 @@ class MatchWinnerWidget extends StatelessWidget {
             const SizedBox(height: 8),
             Text(
               '${l10n.gameDuration} ${_formatDuration(gameDuration)}',
-              style: Theme.of(context)
-                  .textTheme
-                  .bodyLarge
-                  ?.copyWith(fontWeight: FontWeight.w500),
+              style: Theme.of(
+                context,
+              ).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w500),
             ),
           ],
         ),
@@ -304,6 +368,26 @@ class MatchStandingsWidget extends StatelessWidget {
   final String? currentUserFirebaseId;
   final String startingPlayerId;
   final void Function(Player) onSelectPlayer;
+
+  /// Seat identity glyph: the signed-in user, a tagged friend, or an empty
+  /// (assignable) seat.
+  Widget _seatIcon(String? seatFirebaseId, String? currentUserFirebaseId) {
+    if (seatFirebaseId != null && seatFirebaseId == currentUserFirebaseId) {
+      return const Icon(Icons.person, color: Colors.blue, size: 20);
+    }
+    if (seatFirebaseId != null) {
+      return const FaIcon(
+        FontAwesomeIcons.userCheck,
+        color: AppColors.secondary,
+        size: 16,
+      );
+    }
+    return const FaIcon(
+      FontAwesomeIcons.userPlus,
+      color: Colors.grey,
+      size: 16,
+    );
+  }
 
   String _getOrdinalNumber(int number) {
     if (number >= 11 && number <= 13) {
@@ -343,8 +427,8 @@ class MatchStandingsWidget extends StatelessWidget {
                   child: Text(
                     context.l10n.placementColumnHeader,
                     style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                          color: Theme.of(context).colorScheme.secondary,
-                        ),
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
                   ),
                 ),
                 Expanded(
@@ -352,8 +436,8 @@ class MatchStandingsWidget extends StatelessWidget {
                   child: Text(
                     context.l10n.achievementColumnHeader,
                     style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                          color: Theme.of(context).colorScheme.secondary,
-                        ),
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
                   ),
                 ),
                 // Player name and commander header
@@ -361,8 +445,8 @@ class MatchStandingsWidget extends StatelessWidget {
                   child: Text(
                     context.l10n.playerColumnHeader,
                     style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                          color: Theme.of(context).colorScheme.secondary,
-                        ),
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
                   ),
                 ),
               ],
@@ -387,27 +471,16 @@ class MatchStandingsWidget extends StatelessWidget {
                       child: Row(
                         spacing: 8,
                         children: [
-                          if (player.firebaseId != currentUserFirebaseId)
-                            IconButton(
-                              onPressed: () => onSelectPlayer(player),
-                              icon: const FaIcon(
-                                FontAwesomeIcons.userPlus,
-                                color: Colors.grey,
-                                size: 16,
-                              ),
+                          IconButton(
+                            tooltip: player.firebaseId == currentUserFirebaseId
+                                ? l10n.youTooltip
+                                : 'Assign this seat',
+                            onPressed: () => onSelectPlayer(player),
+                            icon: _seatIcon(
+                              player.firebaseId,
+                              currentUserFirebaseId,
                             ),
-                          if (player.firebaseId == currentUserFirebaseId)
-                            Tooltip(
-                              triggerMode: TooltipTriggerMode.tap,
-                              message: l10n.youTooltip,
-                              child: const IconButton(
-                                icon: Icon(
-                                  Icons.person,
-                                  color: Colors.blue,
-                                ),
-                                onPressed: null,
-                              ),
-                            ),
+                          ),
                           if (player.id == startingPlayerId)
                             Tooltip(
                               triggerMode: TooltipTriggerMode.tap,
@@ -425,8 +498,8 @@ class MatchStandingsWidget extends StatelessWidget {
                       child: CircleAvatar(
                         backgroundImage:
                             player.commander?.imageUrl.isNotEmpty ?? false
-                                ? NetworkImage(player.commander!.imageUrl)
-                                : null,
+                            ? NetworkImage(player.commander!.imageUrl)
+                            : null,
                         backgroundColor: Color(player.color),
                       ),
                       onTap: () async {
@@ -551,11 +624,11 @@ class _DeleteMatchButton extends StatelessWidget {
                     child: Text(context.l10n.deleteMatchButtonLabel),
                     onProgressCompleted: () async {
                       context.read<MatchDetailsBloc>().add(
-                            DeleteMatchEvent(
-                              gameId: gameId,
-                              userId: context.read<AppBloc>().state.user.id,
-                            ),
-                          );
+                        DeleteMatchEvent(
+                          gameId: gameId,
+                          userId: context.read<AppBloc>().state.user.id,
+                        ),
+                      );
 
                       context.pop();
                     },

--- a/test/friends_list/friend_stats/friend_head_to_head_calculator_test.dart
+++ b/test/friends_list/friend_stats/friend_head_to_head_calculator_test.dart
@@ -1,0 +1,394 @@
+import 'package:firebase_database_repository/firebase_database_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic_yeti/friends_list/friend_stats/friend_head_to_head.dart';
+import 'package:magic_yeti/friends_list/friend_stats/friend_head_to_head_calculator.dart';
+import 'package:player_repository/player_repository.dart';
+
+const _me = 'me-uid';
+const _friend = 'friend-uid';
+
+/// Fixed game window: noon to 2pm, a 2-hour wall-clock span.
+final _start = DateTime(2026, 1, 1, 12);
+final _end = DateTime(2026, 1, 1, 14);
+
+/// A [timeOfDeath] at [fraction] through the [_start]..[_end] window.
+int _tod(double fraction) =>
+    _start.millisecondsSinceEpoch +
+    (fraction * (_end.millisecondsSinceEpoch - _start.millisecondsSinceEpoch))
+        .round();
+
+Commander _commander(String name, {String? oracleId}) => Commander(
+  name: name,
+  oracleId: oracleId,
+  colors: const ['G'],
+  cardType: 'Legendary Creature',
+  imageUrl: 'img-$name',
+  manaCost: '{G}',
+  oracleText: '',
+  artist: 'Artist',
+);
+
+Opponent _dmg(String dealerId, {int commander = 0, int partner = 0}) =>
+    Opponent(
+      playerId: dealerId,
+      damages: [
+        CommanderDamage(damageType: DamageType.commander, amount: commander),
+        CommanderDamage(damageType: DamageType.partner, amount: partner),
+      ],
+    );
+
+Player _player({
+  required String id,
+  String? firebaseId,
+  int? timeOfDeath,
+  int placement = 2,
+  String? commanderName,
+  String? commanderOracleId,
+  List<Opponent> opponents = const [],
+  PlayerModelState state = PlayerModelState.eliminated,
+}) => Player(
+  id: id,
+  name: 'Name-$id',
+  playerNumber: 0,
+  lifePoints: 40,
+  color: 0xFF000000,
+  opponents: opponents,
+  state: state,
+  placement: placement,
+  timeOfDeath: timeOfDeath,
+  firebaseId: firebaseId,
+  commander: commanderName == null
+      ? null
+      : _commander(commanderName, oracleId: commanderOracleId),
+);
+
+GameModel _game({
+  required String id,
+  required List<Player> players,
+  required String winnerId,
+  DateTime? start,
+  DateTime? end,
+}) => GameModel(
+  id: id,
+  players: players,
+  startTime: start ?? _start,
+  endTime: end ?? _end,
+  winnerId: winnerId,
+  durationInSeconds: 7200,
+);
+
+/// A standard 4-player pod where [meTod]/[friendTod] set the two finishing
+/// times of interest. Two filler seats die early.
+GameModel _pod({
+  required String id,
+  required double meTod,
+  required double friendTod,
+  String winnerId = 'seat-me',
+  List<Opponent> meOpponents = const [],
+  List<Opponent> friendOpponents = const [],
+  String friendCommander = 'Atraxa',
+}) => _game(
+  id: id,
+  winnerId: winnerId,
+  players: [
+    _player(
+      id: 'seat-me',
+      firebaseId: _me,
+      timeOfDeath: _tod(meTod),
+      opponents: meOpponents,
+      commanderName: 'Krenko',
+    ),
+    _player(
+      id: 'seat-friend',
+      firebaseId: _friend,
+      timeOfDeath: _tod(friendTod),
+      opponents: friendOpponents,
+      commanderName: friendCommander,
+    ),
+    _player(id: 'seat-c', timeOfDeath: _tod(0.1)),
+    _player(id: 'seat-d', timeOfDeath: _tod(0.2)),
+  ],
+);
+
+void main() {
+  group('FriendHeadToHeadCalculator.compute', () {
+    test('counts only pods where both accounts occupy distinct seats', () {
+      final games = [
+        _pod(id: 'shared', meTod: 1, friendTod: 0.5),
+        // Only me — friend absent.
+        _game(
+          id: 'solo',
+          winnerId: 'seat-me',
+          players: [
+            _player(id: 'seat-me', firebaseId: _me, timeOfDeath: _tod(1)),
+            _player(id: 'x', timeOfDeath: _tod(0.3)),
+          ],
+        ),
+      ];
+
+      final result = FriendHeadToHeadCalculator.compute(
+        games: games,
+        myId: _me,
+        friendId: _friend,
+      );
+
+      expect(result.sharedPods, 1);
+    });
+
+    test('does not treat one seat as both players when ids collide', () {
+      final games = [_pod(id: 'a', meTod: 1, friendTod: 0.5)];
+
+      final result = FriendHeadToHeadCalculator.compute(
+        games: games,
+        myId: _me,
+        friendId: _me, // same id -> not a real pairing
+      );
+
+      expect(result.sharedPods, 0);
+    });
+
+    test('drops a shared pod when a seat has no parseable time of death', () {
+      // Friend seat is active with no timeOfDeath -> the getter throws; the
+      // pod must be dropped, not crash the whole computation.
+      final broken = _game(
+        id: 'broken',
+        winnerId: 'seat-me',
+        players: [
+          _player(id: 'seat-me', firebaseId: _me, timeOfDeath: _tod(1)),
+          _player(
+            id: 'seat-friend',
+            firebaseId: _friend,
+            state: PlayerModelState.active,
+          ),
+          _player(id: 'z', timeOfDeath: _tod(0.2)),
+        ],
+      );
+
+      final result = FriendHeadToHeadCalculator.compute(
+        games: [
+          broken,
+          _pod(id: 'ok', meTod: 1, friendTod: 0.5),
+        ],
+        myId: _me,
+        friendId: _friend,
+      );
+
+      expect(result.sharedPods, 1);
+    });
+
+    test('The Ledger counts who finished ahead by time of death', () {
+      final games = [
+        _pod(id: '1', meTod: 1.0, friendTod: 0.4), // me ahead
+        _pod(id: '2', meTod: 0.9, friendTod: 0.3), // me ahead
+        _pod(id: '3', meTod: 0.2, friendTod: 0.8), // friend ahead
+      ];
+
+      final result = FriendHeadToHeadCalculator.compute(
+        games: games,
+        myId: _me,
+        friendId: _friend,
+      );
+
+      expect(result.youFinishedAhead, 2);
+      expect(result.theyFinishedAhead, 1);
+    });
+
+    test('Pods Won splits wins between you, them, and the field', () {
+      final games = [
+        _pod(id: '1', meTod: 1, friendTod: 0.5, winnerId: 'seat-me'),
+        _pod(id: '2', meTod: 0.5, friendTod: 1, winnerId: 'seat-friend'),
+        _pod(id: '3', meTod: 0.5, friendTod: 0.4, winnerId: 'seat-c'),
+      ];
+
+      final result = FriendHeadToHeadCalculator.compute(
+        games: games,
+        myId: _me,
+        friendId: _friend,
+      );
+
+      expect(result.youWon, 1);
+      expect(result.theyWon, 1);
+      expect(result.fieldWon, 1);
+      // Expected wins = sum of 1/podSize; all 4-player pods -> 3 * 0.25.
+      expect(result.expectedWinsEach, closeTo(0.75, 1e-9));
+    });
+
+    test('Time Alive averages survival fraction of the wall-clock window', () {
+      final games = [
+        _pod(id: '1', meTod: 1.0, friendTod: 0.5),
+        _pod(id: '2', meTod: 0.5, friendTod: 0.5),
+      ];
+
+      final result = FriendHeadToHeadCalculator.compute(
+        games: games,
+        myId: _me,
+        friendId: _friend,
+      );
+
+      expect(result.yourAvgSurvival, closeTo(0.75, 1e-9));
+      expect(result.theirAvgSurvival, closeTo(0.5, 1e-9));
+    });
+
+    test('Final Two counts pods where the pair are the last two standing', () {
+      final games = [
+        // me + friend are the two latest deaths -> final two.
+        _pod(id: '1', meTod: 1.0, friendTod: 0.9),
+        // filler seat-d at 0.2 beats friend at 0.15 -> NOT final two.
+        _pod(id: '2', meTod: 1.0, friendTod: 0.15),
+      ];
+
+      final result = FriendHeadToHeadCalculator.compute(
+        games: games,
+        myId: _me,
+        friendId: _friend,
+      );
+
+      expect(result.finalTwoCount, 1);
+    });
+
+    test('Beatdown sums commander damage volume both directions', () {
+      final games = [
+        _pod(
+          id: '1',
+          meTod: 1,
+          friendTod: 0.5,
+          // Damage the friend seat took from me (dealer id = seat-me).
+          friendOpponents: [_dmg('seat-me', commander: 10, partner: 3)],
+          // Damage I took from the friend (dealer id = seat-friend).
+          meOpponents: [_dmg('seat-friend', commander: 4)],
+        ),
+      ];
+
+      final result = FriendHeadToHeadCalculator.compute(
+        games: games,
+        myId: _me,
+        friendId: _friend,
+      );
+
+      expect(result.commanderDamageDealt, 13); // 10 + 3
+      expect(result.commanderDamageTaken, 4);
+    });
+
+    test('21s use a single clock, not the summed partner clocks', () {
+      final games = [
+        // 13 + 12 across two clocks = 25 summed, but neither clock hits 21.
+        _pod(
+          id: 'nonlethal',
+          meTod: 1,
+          friendTod: 0.5,
+          friendOpponents: [_dmg('seat-me', commander: 13, partner: 12)],
+        ),
+        // A single clock reaches 21 -> one lethal blow landed.
+        _pod(
+          id: 'lethal',
+          meTod: 1,
+          friendTod: 0.5,
+          friendOpponents: [_dmg('seat-me', commander: 21)],
+        ),
+      ];
+
+      final result = FriendHeadToHeadCalculator.compute(
+        games: games,
+        myId: _me,
+        friendId: _friend,
+      );
+
+      expect(result.lethalBlowsLanded, 1);
+      expect(result.lethalBlowsTaken, 0);
+    });
+
+    test('Their Go-To is their most-played commander, keyed by oracle id', () {
+      final games = [
+        _pod(id: '1', meTod: 1, friendTod: 0.5, friendCommander: 'Atraxa'),
+        _pod(id: '2', meTod: 1, friendTod: 0.5, friendCommander: 'Atraxa'),
+        _pod(id: '3', meTod: 1, friendTod: 0.5, friendCommander: 'Yuriko'),
+      ];
+
+      final result = FriendHeadToHeadCalculator.compute(
+        games: games,
+        myId: _me,
+        friendId: _friend,
+      );
+
+      expect(result.theirTopCommanderName, 'Atraxa');
+      expect(result.theirTopCommanderCount, 2);
+    });
+
+    test('records the earliest shared game date', () {
+      final games = [
+        _game(
+          id: 'later',
+          winnerId: 'seat-me',
+          start: DateTime(2026, 3, 1, 12),
+          end: DateTime(2026, 3, 1, 13),
+          players: [
+            _player(
+              id: 'seat-me',
+              firebaseId: _me,
+              timeOfDeath: DateTime(2026, 3, 1, 13).millisecondsSinceEpoch,
+            ),
+            _player(
+              id: 'seat-friend',
+              firebaseId: _friend,
+              timeOfDeath: DateTime(2026, 3, 1, 12, 30).millisecondsSinceEpoch,
+            ),
+          ],
+        ),
+        _game(
+          id: 'earlier',
+          winnerId: 'seat-me',
+          start: DateTime(2026, 1, 15, 12),
+          end: DateTime(2026, 1, 15, 13),
+          players: [
+            _player(
+              id: 'seat-me',
+              firebaseId: _me,
+              timeOfDeath: DateTime(2026, 1, 15, 13).millisecondsSinceEpoch,
+            ),
+            _player(
+              id: 'seat-friend',
+              firebaseId: _friend,
+              timeOfDeath: DateTime(2026, 1, 15, 12, 30).millisecondsSinceEpoch,
+            ),
+          ],
+        ),
+      ];
+
+      final result = FriendHeadToHeadCalculator.compute(
+        games: games,
+        myId: _me,
+        friendId: _friend,
+      );
+
+      expect(result.firstPlayedTogether, DateTime(2026, 1, 15, 12));
+    });
+
+    test('empty history yields the empty result', () {
+      final result = FriendHeadToHeadCalculator.compute(
+        games: const [],
+        myId: _me,
+        friendId: _friend,
+      );
+
+      expect(result, FriendHeadToHead.empty);
+      expect(result.yourAvgSurvival, isNull);
+      expect(result.theirAvgSurvival, isNull);
+    });
+
+    test('gating getters reflect sample thresholds', () {
+      final threePods = List.generate(
+        3,
+        (i) => _pod(id: '$i', meTod: 1, friendTod: 0.5),
+      );
+
+      final result = FriendHeadToHeadCalculator.compute(
+        games: threePods,
+        myId: _me,
+        friendId: _friend,
+      );
+
+      expect(result.hasEnoughForLedger, isTrue); // >= 3
+      expect(result.hasEnoughForSurvival, isFalse); // needs >= 5
+    });
+  });
+}

--- a/test/friends_list/friend_stats/friend_stats_bloc_test.dart
+++ b/test/friends_list/friend_stats/friend_stats_bloc_test.dart
@@ -1,0 +1,73 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:firebase_database_repository/firebase_database_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic_yeti/friends_list/friend_stats/friend_stats.dart';
+import 'package:player_repository/player_repository.dart';
+
+Player _seat(String id, String firebaseId, int tod) => Player(
+  id: id,
+  name: 'Name-$id',
+  playerNumber: 0,
+  lifePoints: 40,
+  color: 0xFF000000,
+  opponents: const [],
+  placement: 1,
+  timeOfDeath: tod,
+  firebaseId: firebaseId,
+);
+
+GameModel _sharedGame() {
+  final start = DateTime(2026, 1, 1, 12);
+  final end = DateTime(2026, 1, 1, 14);
+  return GameModel(
+    id: 'g1',
+    winnerId: 'me-seat',
+    startTime: start,
+    endTime: end,
+    durationInSeconds: 7200,
+    players: [
+      _seat('me-seat', 'me', end.millisecondsSinceEpoch),
+      _seat('friend-seat', 'friend', start.millisecondsSinceEpoch + 1000),
+    ],
+  );
+}
+
+void main() {
+  group('FriendStatsBloc', () {
+    blocTest<FriendStatsBloc, FriendStatsState>(
+      'emits loading then loaded with computed stats',
+      build: FriendStatsBloc.new,
+      act: (bloc) => bloc.add(
+        CompileFriendStats(
+          myId: 'me',
+          friendId: 'friend',
+          games: [_sharedGame()],
+        ),
+      ),
+      expect: () => [
+        isA<FriendStatsLoading>(),
+        isA<FriendStatsLoaded>().having(
+          (s) => s.stats.sharedPods,
+          'sharedPods',
+          1,
+        ),
+      ],
+    );
+
+    blocTest<FriendStatsBloc, FriendStatsState>(
+      'loaded stats reflect an empty shared history',
+      build: FriendStatsBloc.new,
+      act: (bloc) => bloc.add(
+        const CompileFriendStats(myId: 'me', friendId: 'friend', games: []),
+      ),
+      expect: () => [
+        isA<FriendStatsLoading>(),
+        isA<FriendStatsLoaded>().having(
+          (s) => s.stats.sharedPods,
+          'sharedPods',
+          0,
+        ),
+      ],
+    );
+  });
+}

--- a/test/friends_list/friend_stats/friend_stats_page_test.dart
+++ b/test/friends_list/friend_stats/friend_stats_page_test.dart
@@ -1,0 +1,158 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:firebase_database_repository/firebase_database_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic_yeti/app/bloc/app_bloc.dart';
+import 'package:magic_yeti/friends_list/friend_stats/view/friend_stats_page.dart';
+import 'package:magic_yeti/home/match_history_bloc/match_history_bloc.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:player_repository/player_repository.dart';
+import 'package:user_repository/user_repository.dart';
+
+class _MockAppBloc extends MockBloc<AppEvent, AppState> implements AppBloc {}
+
+class _MockMatchHistoryBloc
+    extends MockBloc<MatchHistoryEvent, MatchHistoryState>
+    implements MatchHistoryBloc {}
+
+Player _seat(String id, String firebaseId, int todMs, {String? commander}) =>
+    Player(
+      id: id,
+      name: 'Name-$id',
+      playerNumber: 0,
+      lifePoints: 40,
+      color: 0xFF000000,
+      opponents: const [],
+      placement: 1,
+      timeOfDeath: todMs,
+      firebaseId: firebaseId,
+      commander: commander == null
+          ? null
+          : Commander(
+              name: commander,
+              colors: const ['G'],
+              cardType: 'Legendary Creature',
+              imageUrl: '',
+              manaCost: '{G}',
+              oracleText: '',
+              artist: 'A',
+            ),
+    );
+
+/// A shared pod where `me` outlasts `friend` when [meAhead] is true.
+GameModel _pod(String id, {required bool meAhead}) {
+  final start = DateTime(2026, 1, 1, 12);
+  final end = DateTime(2026, 1, 1, 14);
+  final meTod = meAhead
+      ? end.millisecondsSinceEpoch
+      : start.millisecondsSinceEpoch + 1000;
+  final friendTod = meAhead
+      ? start.millisecondsSinceEpoch + 1000
+      : end.millisecondsSinceEpoch;
+  return GameModel(
+    id: id,
+    winnerId: meAhead ? 'me-seat' : 'friend-seat',
+    startTime: start,
+    endTime: end,
+    durationInSeconds: 7200,
+    players: [
+      _seat('me-seat', 'me', meTod, commander: 'Krenko'),
+      _seat('friend-seat', 'friend', friendTod, commander: 'Atraxa'),
+    ],
+  );
+}
+
+const _friend = FriendModel(
+  userId: 'friend',
+  username: 'Sam',
+  profilePictureUrl: '',
+  friendCode: '1234',
+);
+
+void main() {
+  late AppBloc appBloc;
+  late MatchHistoryBloc matchHistoryBloc;
+
+  void stubHistory(List<GameModel> games) {
+    final state = MatchHistoryState(
+      status: MatchHistoryStatus.loadingHistorySuccess,
+      userId: 'me',
+      games: games,
+    );
+    when(() => matchHistoryBloc.state).thenReturn(state);
+    whenListen(
+      matchHistoryBloc,
+      const Stream<MatchHistoryState>.empty(),
+      initialState: state,
+    );
+  }
+
+  setUp(() {
+    appBloc = _MockAppBloc();
+    matchHistoryBloc = _MockMatchHistoryBloc();
+    when(
+      () => appBloc.state,
+    ).thenReturn(const AppState.authenticated(User(id: 'me')));
+  });
+
+  Widget buildSubject() {
+    return MaterialApp(
+      home: DeviceInfoProvider(
+        isPhone: true,
+        child: MultiBlocProvider(
+          providers: [
+            BlocProvider<AppBloc>.value(value: appBloc),
+            BlocProvider<MatchHistoryBloc>.value(value: matchHistoryBloc),
+          ],
+          child: const FriendStatsPage(friendId: 'friend', friend: _friend),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders head-to-head stats for the shared pods', (tester) async {
+    stubHistory([
+      _pod('1', meAhead: true),
+      _pod('2', meAhead: true),
+      _pod('3', meAhead: true),
+      _pod('4', meAhead: false),
+      _pod('5', meAhead: false),
+    ]);
+
+    await tester.pumpWidget(buildSubject());
+    await tester.pumpAndSettle();
+
+    // Header names the friend and the shared pod count.
+    expect(find.text('Sam'), findsWidgets);
+    expect(find.textContaining('5 pods together'), findsOneWidget);
+
+    // Hero Ledger: me ahead in 3 of 5.
+    expect(find.text('3–2'), findsOneWidget);
+
+    // Secondary tiles are present.
+    expect(find.text('Pods Won'), findsOneWidget);
+    expect(find.text('Time Alive'), findsOneWidget);
+    expect(find.text('Their Go-To'), findsOneWidget);
+  });
+
+  testWidgets('shows the empty state when no pods are shared', (tester) async {
+    // A game with only me — the friend never shares a seat.
+    stubHistory([
+      GameModel(
+        id: 'solo',
+        winnerId: 'me-seat',
+        startTime: DateTime(2026),
+        endTime: DateTime(2026, 1, 1, 1),
+        durationInSeconds: 3600,
+        players: [_seat('me-seat', 'me', 0)],
+      ),
+    ]);
+
+    await tester.pumpWidget(buildSubject());
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('No shared pods yet'), findsOneWidget);
+  });
+}

--- a/test/friends_list/friend_stats/friend_stats_tiles_test.dart
+++ b/test/friends_list/friend_stats/friend_stats_tiles_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic_yeti/friends_list/friend_stats/friend_head_to_head.dart';
+import 'package:magic_yeti/friends_list/friend_stats/view/friend_stats_tiles.dart';
+
+/// Builds a [FriendHeadToHead] from [FriendHeadToHead.empty], overriding only
+/// the fields a test cares about.
+FriendHeadToHead _stats({
+  int sharedPods = 0,
+  int youFinishedAhead = 0,
+  int theyFinishedAhead = 0,
+  int youWon = 0,
+  int theyWon = 0,
+  int fieldWon = 0,
+  double? yourAvgSurvival,
+  double? theirAvgSurvival,
+  int finalTwoCount = 0,
+  int commanderDamageDealt = 0,
+  int commanderDamageTaken = 0,
+  int lethalBlowsLanded = 0,
+  int lethalBlowsTaken = 0,
+  String? theirTopCommanderName,
+  int theirTopCommanderCount = 0,
+}) {
+  return FriendHeadToHead(
+    sharedPods: sharedPods,
+    firstPlayedTogether: null,
+    youFinishedAhead: youFinishedAhead,
+    theyFinishedAhead: theyFinishedAhead,
+    youWon: youWon,
+    theyWon: theyWon,
+    fieldWon: fieldWon,
+    expectedWinsEach: 0,
+    yourAvgSurvival: yourAvgSurvival,
+    theirAvgSurvival: theirAvgSurvival,
+    finalTwoCount: finalTwoCount,
+    commanderDamageDealt: commanderDamageDealt,
+    commanderDamageTaken: commanderDamageTaken,
+    lethalBlowsLanded: lethalBlowsLanded,
+    lethalBlowsTaken: lethalBlowsTaken,
+    theirTopCommanderName: theirTopCommanderName,
+    theirTopCommanderImageUrl: null,
+    theirTopCommanderCount: theirTopCommanderCount,
+  );
+}
+
+Future<void> _pump(WidgetTester tester, Widget child) {
+  return tester.pumpWidget(
+    MaterialApp(home: Scaffold(body: child)),
+  );
+}
+
+void main() {
+  group('LedgerHeroTile', () {
+    testWidgets('shows the finish record once there are 3+ pods', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        LedgerHeroTile(
+          stats: _stats(
+            sharedPods: 5,
+            youFinishedAhead: 3,
+            theyFinishedAhead: 2,
+          ),
+          friendName: 'Sam',
+        ),
+      );
+
+      expect(find.text('3–2'), findsOneWidget);
+      expect(find.textContaining('you finish ahead in 3 of 5'), findsOneWidget);
+    });
+
+    testWidgets('asks for more pods below the sample gate', (tester) async {
+      await _pump(
+        tester,
+        LedgerHeroTile(
+          stats: _stats(sharedPods: 2, youFinishedAhead: 2),
+          friendName: 'Sam',
+        ),
+      );
+
+      expect(find.textContaining('Need 3+'), findsOneWidget);
+      expect(find.text('2–0'), findsNothing);
+    });
+  });
+
+  group('buildFriendStatTiles', () {
+    testWidgets('hides damage tiles when below their gates', (tester) async {
+      final tiles = buildFriendStatTiles(
+        _stats(sharedPods: 5, commanderDamageDealt: 4),
+      );
+      await _pump(tester, Column(children: tiles));
+
+      expect(find.text('The Beatdown'), findsNothing);
+      expect(find.text('21s'), findsNothing);
+    });
+
+    testWidgets('shows The Beatdown once total flow reaches a clock', (
+      tester,
+    ) async {
+      final tiles = buildFriendStatTiles(
+        _stats(
+          sharedPods: 5,
+          commanderDamageDealt: 18,
+          commanderDamageTaken: 6,
+        ),
+      );
+      await _pump(tester, Column(children: tiles));
+
+      expect(find.text('The Beatdown'), findsOneWidget);
+      expect(find.text('18 / 6'), findsOneWidget);
+    });
+
+    testWidgets('shows 21s only when a lethal blow landed', (tester) async {
+      final tiles = buildFriendStatTiles(
+        _stats(sharedPods: 5, lethalBlowsLanded: 1),
+      );
+      await _pump(tester, Column(children: tiles));
+
+      expect(find.text('21s'), findsOneWidget);
+      expect(find.text('1 / 0'), findsOneWidget);
+    });
+
+    testWidgets('gates Time Alive below five pods', (tester) async {
+      final tiles = buildFriendStatTiles(
+        _stats(sharedPods: 3, yourAvgSurvival: 0.7, theirAvgSurvival: 0.5),
+      );
+      await _pump(tester, Column(children: tiles));
+
+      // Time Alive tile present but showing the need-more sentinel.
+      expect(find.text('Time Alive'), findsOneWidget);
+      expect(find.text('Need 5+'), findsWidgets);
+    });
+  });
+}

--- a/test/match_details/bloc/match_details_bloc_test.dart
+++ b/test/match_details/bloc/match_details_bloc_test.dart
@@ -1,0 +1,142 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:firebase_database_repository/firebase_database_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic_yeti/match_details/bloc/match_details_bloc.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:player_repository/player_repository.dart';
+
+class _MockDatabaseRepository extends Mock
+    implements FirebaseDatabaseRepository {}
+
+Player _seat(String id, {String? firebaseId}) => Player(
+  id: id,
+  name: 'Name-$id',
+  playerNumber: 0,
+  lifePoints: 40,
+  color: 0xFF000000,
+  opponents: const [],
+  placement: 1,
+  timeOfDeath: 0,
+  firebaseId: firebaseId,
+);
+
+GameModel _game(List<Player> players) => GameModel(
+  id: 'game-1',
+  winnerId: 'a',
+  startTime: DateTime(2026),
+  endTime: DateTime(2026, 1, 1, 1),
+  durationInSeconds: 3600,
+  players: players,
+);
+
+void main() {
+  late FirebaseDatabaseRepository repository;
+
+  setUpAll(() {
+    registerFallbackValue(_game([_seat('a')]));
+  });
+
+  setUp(() {
+    repository = _MockDatabaseRepository();
+    when(
+      () => repository.updateGameStats(
+        game: any(named: 'game'),
+        playerId: any(named: 'playerId'),
+      ),
+    ).thenAnswer((_) async {});
+  });
+
+  MatchDetailsBloc buildBloc() =>
+      MatchDetailsBloc(databaseRepository: repository);
+
+  group('AssignSeatIdentity', () {
+    blocTest<MatchDetailsBloc, MatchDetailsState>(
+      'tags a friend onto a seat and writes to the owner history copy',
+      build: buildBloc,
+      act: (bloc) => bloc.add(
+        AssignSeatIdentity(
+          game: _game([_seat('a'), _seat('b')]),
+          seat: _seat('b'),
+          assignedFirebaseId: 'friend-uid',
+          ownerUserId: 'my-uid',
+        ),
+      ),
+      expect: () => [isA<MatchDetailsSuccess>()],
+      verify: (_) {
+        final captured =
+            verify(
+                  () => repository.updateGameStats(
+                    game: captureAny(named: 'game'),
+                    playerId: 'my-uid',
+                  ),
+                ).captured.single
+                as GameModel;
+        final seatB = captured.players.firstWhere((p) => p.id == 'b');
+        expect(seatB.firebaseId, 'friend-uid');
+      },
+    );
+
+    blocTest<MatchDetailsBloc, MatchDetailsState>(
+      'moves an identity off the seat that previously held it',
+      build: buildBloc,
+      act: (bloc) => bloc.add(
+        AssignSeatIdentity(
+          game: _game([
+            _seat('a', firebaseId: 'friend-uid'),
+            _seat('b'),
+          ]),
+          seat: _seat('b'),
+          assignedFirebaseId: 'friend-uid',
+          ownerUserId: 'my-uid',
+        ),
+      ),
+      expect: () => [isA<MatchDetailsSuccess>()],
+      verify: (_) {
+        final captured =
+            verify(
+                  () => repository.updateGameStats(
+                    game: captureAny(named: 'game'),
+                    playerId: any(named: 'playerId'),
+                  ),
+                ).captured.single
+                as GameModel;
+        expect(
+          captured.players.firstWhere((p) => p.id == 'a').firebaseId,
+          isNull,
+        );
+        expect(
+          captured.players.firstWhere((p) => p.id == 'b').firebaseId,
+          'friend-uid',
+        );
+      },
+    );
+
+    blocTest<MatchDetailsBloc, MatchDetailsState>(
+      'unassigns a seat when given a null identity',
+      build: buildBloc,
+      act: (bloc) => bloc.add(
+        AssignSeatIdentity(
+          game: _game([_seat('a', firebaseId: 'my-uid'), _seat('b')]),
+          seat: _seat('a', firebaseId: 'my-uid'),
+          assignedFirebaseId: null,
+          ownerUserId: 'my-uid',
+        ),
+      ),
+      expect: () => [isA<MatchDetailsSuccess>()],
+      verify: (_) {
+        final captured =
+            verify(
+                  () => repository.updateGameStats(
+                    game: captureAny(named: 'game'),
+                    playerId: any(named: 'playerId'),
+                  ),
+                ).captured.single
+                as GameModel;
+        expect(
+          captured.players.firstWhere((p) => p.id == 'a').firebaseId,
+          isNull,
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## What & why

Adds **friend head-to-head Commander stats**: tap a friend in the friends list to see stats over the pods you've played together, plus a way to retro-tag friends into past games.

The stat selection was driven by a consult with a purpose-built **Commander-format expert agent** (`.claude/agents/commander-expert.md`; conversation in `docs/superpowers/notes/`). Its key insight shaped the whole screen: at the real sample size (most friend pairs have **3–15 shared pods, ever**) win-rate percentages are statistical noise and get misread against a 50% baseline that doesn't apply to a 4-player pod. So the screen is built on **counts, not percentages**, headlined by *who finishes ahead* — a 50% event defined in every pod — instead of *who wins*, a 25% event you rarely have enough of.

## The stats screen

Tap a friend → `FriendStatsPage`:

| Tile | Shows |
|---|---|
| **The Ledger** *(hero)* | Pods you finished ahead of them vs behind — `3–2` |
| **Pods Won** | `You · Them · Rest of table` (self-normalizing, no %) |
| **Time Alive** | Mean share of the pod each of you survives |
| **Final Two** | How often you two were the last standing |
| **The Beatdown** | Commander damage traded each way (hidden if trivial) |
| **21s** | 21-damage commander kills (shown only if ≥1) |
| **Their Go-To** | Their most-played commander at your table |
| **Pods Together** | Shared pod count + first date (header) |

Tiles gate to sample size (Ledger/Pods Won/Their Go-To at 3 pods; Time Alive/Final Two at 5; damage tiles hide entirely below one clock's worth rather than showing `0–0`). All-time only — a time-range filter would empty small samples.

## Backfill

The match-details seat control now assigns any seat to **Me / a friend / nobody** (generalizes the old `UpdatePlayerOwnership` → `AssignSeatIdentity`). Tagging a friend writes to *your own* history copy only — a private annotation they never see. Also fixes a latent bug where the standings "You" marker keyed off `hostId` instead of the signed-in user.

## Architecture — no backend changes

`onGameCreated` already fans every game into each participant's `users/{uid}/matches`, so the user's own history contains every shared pod. Stats compute client-side — **no Cloud Function, no rules change, no index**. The friend's owner-only history is never read.

Compute lives in a pure, fully-unit-tested `FriendHeadToHeadCalculator`; `FriendStatsBloc` is a thin wrapper fed games from the app-wide `MatchHistoryBloc` (same pattern as the existing stats overview).

## Correctness rules (test-locked)

Verified against the game/player models and locked with tests:
- Require **both** accounts on **distinct** seats — no `_findPlayerInGame`-style fallback that would fabricate a rivalry from an untagged seat.
- Order by `timeOfDeath` (strictly ordered; winner stamped at game end), **not** `placement`, which can collide when a player is revived.
- Per-clock 21-damage lethality (`any(>=21)`); damage *volume* sums both clocks (`fold`).
- Survival fraction normalizes against wall-clock (`endTime − startTime`), not the pausable `durationInSeconds`.
- Defensive reads of the throwing `placement`/`timeOfDeath` getters; unparseable legacy games are dropped, not crashed on.

## Tests

- **26 new tests**; full suite **209 passing**. `flutter analyze`: 0 errors, 0 issues in the new files.
- Includes a widget test that pumps the **real page** with real game data and asserts the Ledger, tiles, and empty state render.

## Follow-ups (out of scope)

- The existing personal-stats "killed by commander" tile (`stats_overview_bloc.dart:507`) sums both Partner clocks and over-counts 21s — flagged for a separate fix (the new calculator already does it correctly).
- Documented v1 limitations: concessions look like deaths (no concession data); "who killed you most" — the best pairwise Commander stat — needs a `killedBy` field that doesn't exist yet. Both are on the wishlist in the consult notes.

Design doc: `docs/superpowers/specs/2026-07-17-friend-head-to-head-stats-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
