### PR TITLE
fix: count commander-damage kills per clock, not in aggregate

### DIFF
--- a/lib/stats_overview/stats_overview_bloc/stats_overview_bloc.dart
+++ b/lib/stats_overview/stats_overview_bloc/stats_overview_bloc.dart
@@ -504,9 +504,13 @@ class StatsOverviewBloc extends Bloc<StatsOverviewEvent, StatsOverviewState> {
       final player = _findPlayerInGame(game, userId);
       if (player.opponents == null) continue;
       for (final opponent in player.opponents!) {
-        final totalFromOpponent =
-            opponent.damages.fold<int>(0, (sum, d) => sum + d.amount);
-        if (totalFromOpponent >= 21) {
+        // Commander damage is lethal per clock, not in aggregate: a Partner
+        // pair's commander and partner clocks each need to reach 21 on their
+        // own (13 + 12 sums to 25 but kills nobody). Mirrors the game-end
+        // check in `PlayerRepository._checkPlayerDeath`.
+        final landedLethalClock =
+            opponent.damages.any((d) => d.amount >= 21);
+        if (landedLethalClock) {
           count++;
           break;
         }

--- a/test/stats_overview/stats_overview_bloc/stats_overview_bloc_test.dart
+++ b/test/stats_overview/stats_overview_bloc/stats_overview_bloc_test.dart
@@ -56,6 +56,37 @@ GameModel _game({
   );
 }
 
+/// Builds a single-player game where the user `alice` carries [opponents] —
+/// the commander-damage clocks recorded against them. Used to exercise
+/// `_calculateTimesKilledByCommander` through the compiled state.
+GameModel _gameWithDamages({
+  required String id,
+  required List<Opponent> opponents,
+}) {
+  final player = Player(
+    id: 'p1',
+    name: 'Player 1',
+    playerNumber: 1,
+    lifePoints: 0,
+    color: 0xFF000000,
+    opponents: opponents,
+    placement: 4,
+    firebaseId: 'alice',
+  );
+  return GameModel(
+    id: id,
+    players: [player],
+    startTime: DateTime(2020),
+    endTime: DateTime(2020, 1, 1, 1),
+    winnerId: 'p1',
+    durationInSeconds: 3600,
+  );
+}
+
+/// A single opponent dealing [damages] to the user.
+Opponent _foeDealing(List<CommanderDamage> damages) =>
+    Opponent(playerId: 'foe', damages: damages);
+
 void main() {
   late ScryfallRepository scryfallRepository;
 
@@ -122,6 +153,75 @@ void main() {
           isA<StatsOverviewLoaded>()
               .having((s) => s.range, 'range', StatsTimeRange.allTime)
               .having((s) => s.games.length, 'games.length', 2),
+        ],
+      );
+    });
+
+    group('timesKilledByCommander', () {
+      blocTest<StatsOverviewBloc, StatsOverviewState>(
+        'does not count a partner pair whose two clocks (13 + 12) each stay '
+        'below 21, even though they sum past it',
+        build: buildBloc,
+        act: (bloc) => bloc.add(
+          CompileStatsOverviewData(
+            userId: 'alice',
+            games: [
+              _gameWithDamages(
+                id: 'split',
+                opponents: [
+                  _foeDealing([
+                    CommanderDamage(
+                      damageType: DamageType.commander,
+                      amount: 13,
+                    ),
+                    CommanderDamage(
+                      damageType: DamageType.partner,
+                      amount: 12,
+                    ),
+                  ]),
+                ],
+              ),
+            ],
+          ),
+        ),
+        expect: () => [
+          isA<StatsOverviewLoading>(),
+          isA<StatsOverviewLoaded>().having(
+            (s) => s.timesKilledByCommander,
+            'timesKilledByCommander',
+            0,
+          ),
+        ],
+      );
+
+      blocTest<StatsOverviewBloc, StatsOverviewState>(
+        'counts a single clock that reaches 21',
+        build: buildBloc,
+        act: (bloc) => bloc.add(
+          CompileStatsOverviewData(
+            userId: 'alice',
+            games: [
+              _gameWithDamages(
+                id: 'lethal',
+                opponents: [
+                  _foeDealing([
+                    CommanderDamage(
+                      damageType: DamageType.commander,
+                      amount: 21,
+                    ),
+                  ]),
+                ],
+              ),
+            ],
+          ),
+        ),
+        expect: () => [
+          isA<StatsOverviewLoading>(),
+          isA<StatsOverviewLoaded>().having(
+            (s) => s.timesKilledByCommander,
+            'timesKilledByCommander',
+            1,
+          ),
         ],
       );
     });


### PR DESCRIPTION
## Problem

The `timesKilledByCommander` stat in `StatsOverviewBloc` summed a Partner pair's two commander-damage clocks before comparing to 21. A Partner pair dealing 13 (commander clock) + 12 (partner clock) sums to 25 and was miscounted as a kill — but neither clock reached 21, so it kills nobody.

Commander damage is lethal **per clock**, not in aggregate.

## Fix

Switch from folding the clocks together to per-clock lethality:

```dart
opponent.damages.any((d) => d.amount >= 21)
```

This mirrors the authoritative game-end check in `PlayerRepository._checkPlayerDeath` (`packages/player_repository/lib/src/player_repository.dart:136`).

## Tests

Added a `timesKilledByCommander` group to `stats_overview_bloc_test.dart`:
- **Split Partner pair (13 + 12)** → does **not** count (the regression case)
- **Single clock reaching 21** → counts

Written test-first: the split-pair test failed under the old aggregate logic (returned `1`, expected `0`) and passes after the fix. All tests in the file pass; `flutter analyze` surfaces only a pre-existing lint unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)