### PR TITLE
feat: friend head-to-head stats — date filter, responsive layout, descriptive tiles

### DIFF
--- a/docs/superpowers/plans/2026-07-17-friend-stats-improvements.md
+++ b/docs/superpowers/plans/2026-07-17-friend-stats-improvements.md
@@ -1,0 +1,894 @@
+# Friend Head-to-Head Stats Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a date-range filter that drives the whole friend head-to-head page, tighten the stat grid, and make each tile self-descriptive with a caption line.
+
+**Architecture:** `FriendStatsBloc` retains the compiled inputs as fields and re-filters/recomputes synchronously on a new `FriendStatsRangeChanged` event (no generation fence needed — compute is synchronous). The page gains a right-aligned `StatsTimeRange` dropdown (reused from home stats) and an "empty in this range" body. A new local `FriendStatCard` (title + value + caption) replaces the shared `StatsWidget` inside the friend grid; the shared widget is untouched.
+
+**Tech Stack:** Flutter, `bloc`/`flutter_bloc`, `equatable`, `bloc_test`, `auto_size_text`, `app_ui`.
+
+## Global Constraints
+
+- Reuse `StatsTimeRange` from `lib/stats_overview/stats_overview_bloc/stats_overview_bloc.dart` (exported by `package:magic_yeti/stats_overview/stats_overview.dart`) — do NOT define a second enum.
+- Filter games by `game.endTime.isAfter(cutoff)`; cutoff arithmetic must match `StatsOverviewBloc._filterGames` exactly.
+- Do NOT modify `FriendHeadToHeadCalculator`, the `FriendHeadToHead` model, or the shared `StatsWidget`.
+- Lint: `very_good_analysis` (strict). Run `flutter analyze` before each commit.
+- Tests run from repo root with `flutter test <path>`.
+
+---
+
+## File Structure
+
+- `lib/friends_list/friend_stats/friend_stats_bloc.dart` — add range field, `_filterGames`, `_emitCompiled`, new event handler.
+- `lib/friends_list/friend_stats/friend_stats_event.dart` — add `FriendStatsRangeChanged`.
+- `lib/friends_list/friend_stats/friend_stats_state.dart` — add `range` to `FriendStatsLoaded`.
+- `lib/friends_list/friend_stats/view/friend_stats_tiles.dart` — add `FriendStatCard`; captions in `buildFriendStatTiles`.
+- `lib/friends_list/friend_stats/view/friend_stats_page.dart` — dropdown, empty-in-range body, grid tuning.
+- Tests: `test/friends_list/friend_stats/friend_stats_bloc_test.dart`, `friend_stats_tiles_test.dart`, `friend_stats_page_test.dart`.
+
+---
+
+## Task 1: Bloc range filter
+
+**Files:**
+- Modify: `lib/friends_list/friend_stats/friend_stats_event.dart`
+- Modify: `lib/friends_list/friend_stats/friend_stats_state.dart`
+- Modify: `lib/friends_list/friend_stats/friend_stats_bloc.dart`
+- Test: `test/friends_list/friend_stats/friend_stats_bloc_test.dart`
+
+**Interfaces:**
+- Consumes: `StatsTimeRange` (enum with `.allTime`, `.last12Months`, `.last6Months`, `.last3Months`, `.last30Days`) from `package:magic_yeti/stats_overview/stats_overview.dart`.
+- Produces:
+  - `FriendStatsRangeChanged(StatsTimeRange range)` event.
+  - `FriendStatsLoaded(FriendHeadToHead stats, {StatsTimeRange range})` — `range` defaults to `StatsTimeRange.allTime`.
+
+- [ ] **Step 1: Write the failing bloc tests**
+
+Replace the entire body of `test/friends_list/friend_stats/friend_stats_bloc_test.dart` with:
+
+```dart
+import 'package:bloc_test/bloc_test.dart';
+import 'package:firebase_database_repository/firebase_database_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic_yeti/friends_list/friend_stats/friend_stats.dart';
+import 'package:magic_yeti/stats_overview/stats_overview.dart';
+import 'package:player_repository/player_repository.dart';
+
+Player _seat(String id, String firebaseId, int tod) => Player(
+  id: id,
+  name: 'Name-$id',
+  playerNumber: 0,
+  lifePoints: 40,
+  color: 0xFF000000,
+  opponents: const [],
+  placement: 1,
+  timeOfDeath: tod,
+  firebaseId: firebaseId,
+);
+
+/// A shared pod (me + friend) ending at [end]. `me` wins.
+GameModel _sharedGameAt(DateTime end) {
+  final start = end.subtract(const Duration(hours: 2));
+  return GameModel(
+    id: 'g-${end.millisecondsSinceEpoch}',
+    winnerId: 'me-seat',
+    startTime: start,
+    endTime: end,
+    durationInSeconds: 7200,
+    players: [
+      _seat('me-seat', 'me', end.millisecondsSinceEpoch),
+      _seat('friend-seat', 'friend', start.millisecondsSinceEpoch + 1000),
+    ],
+  );
+}
+
+void main() {
+  group('FriendStatsBloc', () {
+    blocTest<FriendStatsBloc, FriendStatsState>(
+      'emits loading then loaded with computed stats, range all-time',
+      build: FriendStatsBloc.new,
+      act: (bloc) => bloc.add(
+        CompileFriendStats(
+          myId: 'me',
+          friendId: 'friend',
+          games: [_sharedGameAt(DateTime(2026, 1, 1, 14))],
+        ),
+      ),
+      expect: () => [
+        isA<FriendStatsLoading>(),
+        isA<FriendStatsLoaded>()
+            .having((s) => s.stats.sharedPods, 'sharedPods', 1)
+            .having((s) => s.range, 'range', StatsTimeRange.allTime),
+      ],
+    );
+
+    blocTest<FriendStatsBloc, FriendStatsState>(
+      'loaded stats reflect an empty shared history',
+      build: FriendStatsBloc.new,
+      act: (bloc) => bloc.add(
+        const CompileFriendStats(myId: 'me', friendId: 'friend', games: []),
+      ),
+      expect: () => [
+        isA<FriendStatsLoading>(),
+        isA<FriendStatsLoaded>().having(
+          (s) => s.stats.sharedPods,
+          'sharedPods',
+          0,
+        ),
+      ],
+    );
+
+    blocTest<FriendStatsBloc, FriendStatsState>(
+      'range change filters games by endTime and recomputes',
+      build: FriendStatsBloc.new,
+      act: (bloc) {
+        final now = DateTime.now();
+        bloc
+          ..add(
+            CompileFriendStats(
+              myId: 'me',
+              friendId: 'friend',
+              games: [
+                _sharedGameAt(now.subtract(const Duration(days: 5))),
+                _sharedGameAt(now.subtract(const Duration(days: 400))),
+              ],
+            ),
+          )
+          ..add(const FriendStatsRangeChanged(StatsTimeRange.last30Days));
+      },
+      // Skip the loading+loaded pair emitted by the initial compile.
+      skip: 2,
+      expect: () => [
+        isA<FriendStatsLoading>(),
+        isA<FriendStatsLoaded>()
+            .having((s) => s.stats.sharedPods, 'sharedPods', 1)
+            .having((s) => s.range, 'range', StatsTimeRange.last30Days),
+      ],
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/friends_list/friend_stats/friend_stats_bloc_test.dart`
+Expected: FAIL — `FriendStatsRangeChanged` undefined and `FriendStatsLoaded` has no `range`.
+
+- [ ] **Step 3: Add the `FriendStatsRangeChanged` event**
+
+In `lib/friends_list/friend_stats/friend_stats_event.dart`, append after the `CompileFriendStats` class (still inside the file, it is `part of 'friend_stats_bloc.dart'`):
+
+```dart
+/// Change the time window the head-to-head stats are computed over. Reuses the
+/// retained games/ids from the last [CompileFriendStats].
+final class FriendStatsRangeChanged extends FriendStatsEvent {
+  const FriendStatsRangeChanged(this.range);
+
+  final StatsTimeRange range;
+
+  @override
+  List<Object?> get props => [range];
+}
+```
+
+- [ ] **Step 4: Add `range` to `FriendStatsLoaded`**
+
+In `lib/friends_list/friend_stats/friend_stats_state.dart`, replace the `FriendStatsLoaded` class with:
+
+```dart
+final class FriendStatsLoaded extends FriendStatsState {
+  const FriendStatsLoaded(this.stats, {this.range = StatsTimeRange.allTime});
+
+  final FriendHeadToHead stats;
+  final StatsTimeRange range;
+
+  @override
+  List<Object?> get props => [stats, range];
+}
+```
+
+- [ ] **Step 5: Wire the range filter into the bloc**
+
+Replace the whole body of `lib/friends_list/friend_stats/friend_stats_bloc.dart` with:
+
+```dart
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:firebase_database_repository/firebase_database_repository.dart';
+import 'package:magic_yeti/friends_list/friend_stats/friend_head_to_head.dart';
+import 'package:magic_yeti/friends_list/friend_stats/friend_head_to_head_calculator.dart';
+import 'package:magic_yeti/stats_overview/stats_overview.dart';
+
+part 'friend_stats_event.dart';
+part 'friend_stats_state.dart';
+
+/// Computes head-to-head stats between the signed-in user and one friend from
+/// the user's own match history, over a selectable [StatsTimeRange].
+///
+/// Games are injected via [CompileFriendStats] (from the app-wide match-history
+/// stream) and retained as fields so [FriendStatsRangeChanged] can re-filter and
+/// recompute without re-fetching. Computation is synchronous and cheap, so no
+/// generation fence is needed — events cannot interleave across an await here.
+class FriendStatsBloc extends Bloc<FriendStatsEvent, FriendStatsState> {
+  FriendStatsBloc() : super(FriendStatsInitial()) {
+    on<CompileFriendStats>(_onCompile);
+    on<FriendStatsRangeChanged>(_onRangeChanged);
+  }
+
+  List<GameModel> _allGames = const [];
+  String _myId = '';
+  String _friendId = '';
+  StatsTimeRange _range = StatsTimeRange.allTime;
+
+  void _onCompile(CompileFriendStats event, Emitter<FriendStatsState> emit) {
+    _allGames = event.games;
+    _myId = event.myId;
+    _friendId = event.friendId;
+    _emitCompiled(emit);
+  }
+
+  void _onRangeChanged(
+    FriendStatsRangeChanged event,
+    Emitter<FriendStatsState> emit,
+  ) {
+    _range = event.range;
+    _emitCompiled(emit);
+  }
+
+  void _emitCompiled(Emitter<FriendStatsState> emit) {
+    emit(FriendStatsLoading());
+    try {
+      final games = _filterGames(_allGames, _range);
+      final stats = FriendHeadToHeadCalculator.compute(
+        games: games,
+        myId: _myId,
+        friendId: _friendId,
+      );
+      emit(FriendStatsLoaded(stats, range: _range));
+    } on Object catch (error) {
+      emit(FriendStatsFailure(error.toString()));
+    }
+  }
+
+  /// Keeps games whose `endTime` is after the cutoff for [range]. Mirrors
+  /// `StatsOverviewBloc._filterGames` so the two pages agree on boundaries.
+  List<GameModel> _filterGames(List<GameModel> games, StatsTimeRange range) {
+    if (range == StatsTimeRange.allTime) {
+      return games;
+    }
+    final now = DateTime.now();
+    final cutoff = switch (range) {
+      StatsTimeRange.last12Months => DateTime(now.year - 1, now.month, now.day),
+      StatsTimeRange.last6Months => DateTime(now.year, now.month - 6, now.day),
+      StatsTimeRange.last3Months => DateTime(now.year, now.month - 3, now.day),
+      StatsTimeRange.last30Days => now.subtract(const Duration(days: 30)),
+      StatsTimeRange.allTime => now,
+    };
+    return games.where((game) => game.endTime.isAfter(cutoff)).toList();
+  }
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `flutter test test/friends_list/friend_stats/friend_stats_bloc_test.dart`
+Expected: PASS (3 tests).
+
+- [ ] **Step 7: Analyze**
+
+Run: `flutter analyze lib/friends_list/friend_stats`
+Expected: No issues.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/friends_list/friend_stats/friend_stats_bloc.dart \
+        lib/friends_list/friend_stats/friend_stats_event.dart \
+        lib/friends_list/friend_stats/friend_stats_state.dart \
+        test/friends_list/friend_stats/friend_stats_bloc_test.dart
+git commit -m "feat: filter friend head-to-head stats by time range"
+```
+
+---
+
+## Task 2: Self-descriptive `FriendStatCard`
+
+**Files:**
+- Modify: `lib/friends_list/friend_stats/view/friend_stats_tiles.dart`
+- Test: `test/friends_list/friend_stats/friend_stats_tiles_test.dart`
+
+**Interfaces:**
+- Produces: `FriendStatCard({required String title, required String stat, required String caption, String? tooltip})` — a `Card` rendering title (+ optional info button) / value / caption.
+- `buildFriendStatTiles(FriendHeadToHead stats)` continues to return `List<Widget>`, now `FriendStatCard`s, with the "Time Alive" title renamed to "Avg Time Alive".
+
+- [ ] **Step 1: Update the failing tile tests**
+
+In `test/friends_list/friend_stats/friend_stats_tiles_test.dart`, make these edits:
+
+Change the "gates Time Alive" test's expectation from `'Time Alive'` to `'Avg Time Alive'`:
+
+```dart
+    testWidgets('gates Time Alive below five pods', (tester) async {
+      final tiles = buildFriendStatTiles(
+        _stats(sharedPods: 3, yourAvgSurvival: 0.7, theirAvgSurvival: 0.5),
+      );
+      await _pump(tester, Column(children: tiles));
+
+      // Time Alive tile present but showing the need-more sentinel.
+      expect(find.text('Avg Time Alive'), findsOneWidget);
+      expect(find.text('Need 5+'), findsWidgets);
+    });
+```
+
+Add a new test inside the `buildFriendStatTiles` group verifying captions render:
+
+```dart
+    testWidgets('renders captions under the values', (tester) async {
+      final tiles = buildFriendStatTiles(
+        _stats(sharedPods: 5, youWon: 3, theyWon: 1, fieldWon: 1),
+      );
+      await _pump(tester, Column(children: tiles));
+
+      expect(find.text('You · Them · Field'), findsOneWidget);
+      expect(find.text('3·1·1'), findsOneWidget);
+    });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/friends_list/friend_stats/friend_stats_tiles_test.dart`
+Expected: FAIL — `'Avg Time Alive'` and `'You · Them · Field'` not found (still "Time Alive", no captions).
+
+- [ ] **Step 3: Add `FriendStatCard` and use it in `buildFriendStatTiles`**
+
+Replace the whole body of `lib/friends_list/friend_stats/view/friend_stats_tiles.dart` with:
+
+```dart
+import 'dart:async';
+
+import 'package:app_ui/app_ui.dart';
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:magic_yeti/friends_list/friend_stats/friend_head_to_head.dart';
+
+/// The hero tile: a pairwise finish record. This is the one stat with both a
+/// real sample and a real story at ~10 pods — "who finishes ahead" is defined
+/// in every shared pod with a true 50% baseline, unlike a 25%-event win rate.
+class LedgerHeroTile extends StatelessWidget {
+  const LedgerHeroTile({
+    required this.stats,
+    required this.friendName,
+    super.key,
+  });
+
+  final FriendHeadToHead stats;
+  final String friendName;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final enough = stats.hasEnoughForLedger;
+
+    return Card(
+      color: AppColors.surface,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+        child: Column(
+          children: [
+            Text(
+              'The Ledger',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: AppColors.secondary,
+              ),
+            ),
+            const SizedBox(height: 8),
+            if (enough) ...[
+              Text(
+                '${stats.youFinishedAhead}–${stats.theyFinishedAhead}',
+                style: theme.textTheme.displaySmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'you finish ahead in ${stats.youFinishedAhead} '
+                'of ${stats.sharedPods} pods',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: AppColors.neutral60,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ] else
+              Text(
+                'Need 3+ pods together',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: AppColors.neutral60,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A single secondary head-to-head stat as a card: a clear title (with an
+/// optional info button for the full explanation), the value, and a caption
+/// that names what the value means so the info button is rarely needed.
+class FriendStatCard extends StatelessWidget {
+  const FriendStatCard({
+    required this.title,
+    required this.stat,
+    required this.caption,
+    this.tooltip,
+    super.key,
+  });
+
+  final String title;
+  final String stat;
+  final String caption;
+  final String? tooltip;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      color: AppColors.surface,
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 6),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Flexible(
+                  child: AutoSizeText(
+                    title,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      color: Colors.blueGrey,
+                    ),
+                    textAlign: TextAlign.center,
+                    maxLines: 1,
+                  ),
+                ),
+                if (tooltip != null)
+                  Padding(
+                    padding: const EdgeInsets.only(left: 2),
+                    child: GestureDetector(
+                      onTap: () => _showTooltip(context),
+                      child: Icon(
+                        Icons.info_outline,
+                        size: 10,
+                        color: Colors.blueGrey.withAlpha(150),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Expanded(
+              child: Center(
+                child: AutoSizeText(
+                  stat,
+                  style: theme.textTheme.headlineSmall,
+                  textAlign: TextAlign.center,
+                  maxLines: 2,
+                ),
+              ),
+            ),
+            const SizedBox(height: 4),
+            AutoSizeText(
+              caption,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: AppColors.neutral60,
+              ),
+              textAlign: TextAlign.center,
+              maxLines: 2,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showTooltip(BuildContext context) {
+    unawaited(
+      showDialog<void>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: Text(
+            title,
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          content: Text(tooltip!),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Builds the secondary stat tiles for the grid, applying each stat's sample
+/// gate. Damage tiles (The Beatdown, 21s) are omitted entirely below their
+/// gates rather than shown as a rivalry of zeroes.
+List<Widget> buildFriendStatTiles(FriendHeadToHead stats) {
+  int pct(double? f) => ((f ?? 0) * 100).round();
+
+  return [
+    FriendStatCard(
+      title: 'Pods Won',
+      stat: stats.hasEnoughForLedger
+          ? '${stats.youWon}·${stats.theyWon}·${stats.fieldWon}'
+          : 'Need 3+',
+      caption: 'You · Them · Field',
+      tooltip:
+          'You · Them · Rest of the table, across ${stats.sharedPods} '
+          'pods. An even split would be about '
+          '${stats.expectedWinsEach.toStringAsFixed(1)} each — in a 4-player '
+          'pod the baseline is 25%, not 50%.',
+    ),
+    FriendStatCard(
+      title: 'Their Go-To',
+      stat: stats.hasEnoughForTopCommander
+          ? (stats.theirTopCommanderName ?? 'Need 3+')
+          : 'Need 3+',
+      caption: 'Most-played cmdr',
+      tooltip: stats.hasEnoughForTopCommander
+          ? 'The commander they bring to your table most often '
+                '(${stats.theirTopCommanderCount} of ${stats.sharedPods} pods).'
+          : 'Their most-played commander at your table (needs 3+ pods).',
+    ),
+    FriendStatCard(
+      title: 'Avg Time Alive',
+      stat: stats.hasEnoughForSurvival
+          ? '${pct(stats.yourAvgSurvival)}% / ${pct(stats.theirAvgSurvival)}%'
+          : 'Need 5+',
+      caption: 'You / Them survived',
+      tooltip:
+          'Average share of the pod each of you survives — you / them. '
+          'The Ledger says who outlasts whom; this says by how much.',
+    ),
+    FriendStatCard(
+      title: 'Final Two',
+      stat: stats.hasEnoughForFinalTwo
+          ? '${stats.finalTwoCount} of ${stats.sharedPods}'
+          : 'Need 5+',
+      caption: 'Last two standing',
+      tooltip:
+          'Pods where the two of you were the last players standing — '
+          'the mark of a real rivalry.',
+    ),
+    if (stats.hasBeatdown)
+      FriendStatCard(
+        title: 'The Beatdown',
+        stat: '${stats.commanderDamageDealt} / ${stats.commanderDamageTaken}',
+        caption: 'Cmdr dmg dealt / taken',
+        tooltip:
+            'Total commander damage you have dealt to them / taken from '
+            'them across your shared pods.',
+      ),
+    if (stats.hasLethalBlows)
+      FriendStatCard(
+        title: '21s',
+        stat: '${stats.lethalBlowsLanded} / ${stats.lethalBlowsTaken}',
+        caption: 'Lethal 21s: you / them',
+        tooltip:
+            'Pods where a single commander landed the lethal 21 — you on '
+            'them / them on you.',
+      ),
+  ];
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `flutter test test/friends_list/friend_stats/friend_stats_tiles_test.dart`
+Expected: PASS (all tests, including the new caption test).
+
+- [ ] **Step 5: Analyze**
+
+Run: `flutter analyze lib/friends_list/friend_stats`
+Expected: No issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/friends_list/friend_stats/view/friend_stats_tiles.dart \
+        test/friends_list/friend_stats/friend_stats_tiles_test.dart
+git commit -m "feat: descriptive caption cards for friend head-to-head tiles"
+```
+
+---
+
+## Task 3: Page dropdown, empty-in-range body, tighter grid
+
+**Files:**
+- Modify: `lib/friends_list/friend_stats/view/friend_stats_page.dart`
+- Test: `test/friends_list/friend_stats/friend_stats_page_test.dart`
+
+**Interfaces:**
+- Consumes: `FriendStatsLoaded.range` (Task 1), `FriendStatsRangeChanged` (Task 1), `FriendStatCard` (Task 2), `StatsTimeRange` (from `package:magic_yeti/stats_overview/stats_overview.dart`).
+- Produces: no new exports.
+
+- [ ] **Step 1: Update the failing page tests**
+
+In `test/friends_list/friend_stats/friend_stats_page_test.dart`:
+
+Add these imports at the top with the others:
+
+```dart
+import 'package:magic_yeti/stats_overview/stats_overview.dart';
+```
+
+In the "renders head-to-head stats for the shared pods" test, change the `'Time Alive'` expectation to `'Avg Time Alive'`:
+
+```dart
+    expect(find.text('Pods Won'), findsOneWidget);
+    expect(find.text('Avg Time Alive'), findsOneWidget);
+    expect(find.text('Their Go-To'), findsOneWidget);
+```
+
+Add a new test after the existing "shows the empty state when no pods are shared" test. It plays real (past-dated) pods, switches the range to Last 30 Days, and expects the in-range-empty body with the dropdown still present:
+
+```dart
+  testWidgets('shows an in-range empty body when the range hides all pods', (
+    tester,
+  ) async {
+    // Pods dated Jan 2026 — outside a Last-30-Days window as of the run date.
+    stubHistory([
+      _pod('1', meAhead: true),
+      _pod('2', meAhead: true),
+      _pod('3', meAhead: true),
+    ]);
+
+    await tester.pumpWidget(buildSubject());
+    await tester.pumpAndSettle();
+
+    // Open the range dropdown and pick Last 30 Days.
+    await tester.tap(find.byType(DropdownButton<StatsTimeRange>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Last 30 Days').last);
+    await tester.pumpAndSettle();
+
+    // In-range empty message shows, and the dropdown is still available to
+    // widen the range back out.
+    expect(find.textContaining('No shared pods in this range'), findsOneWidget);
+    expect(find.byType(DropdownButton<StatsTimeRange>), findsOneWidget);
+    // Not the all-time "never played" empty state.
+    expect(find.textContaining('No shared pods yet'), findsNothing);
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/friends_list/friend_stats/friend_stats_page_test.dart`
+Expected: FAIL — no `DropdownButton<StatsTimeRange>`, `'Avg Time Alive'` not found.
+
+- [ ] **Step 3: Add the dropdown, range wiring, empty-in-range body, and grid tuning**
+
+In `lib/friends_list/friend_stats/view/friend_stats_page.dart`:
+
+3a. Add the stats-overview import (for `StatsTimeRange`) with the other imports:
+
+```dart
+import 'package:magic_yeti/stats_overview/stats_overview.dart';
+```
+
+3b. Add a range-change handler to `_FriendStatsViewState` (next to `_compile`):
+
+```dart
+  void _onRangeChanged(StatsTimeRange? range) {
+    if (range == null) return;
+    context.read<FriendStatsBloc>().add(FriendStatsRangeChanged(range));
+  }
+```
+
+3c. Pass `range` and the handler into the body. Replace the `FriendStatsLoaded` switch arm with:
+
+```dart
+              FriendStatsLoaded(:final stats, :final range) => _FriendStatsBody(
+                friendName: _friendName,
+                friend: widget.friend,
+                stats: stats,
+                range: range,
+                onRangeChanged: _onRangeChanged,
+              ),
+```
+
+3d. Replace the `_FriendStatsBody` class with the version below. It: keeps the "never played" empty state only for all-time-with-zero-pods; otherwise always renders the dropdown, then either the stats or an in-range-empty message; and tightens the grid.
+
+```dart
+class _FriendStatsBody extends StatelessWidget {
+  const _FriendStatsBody({
+    required this.friendName,
+    required this.friend,
+    required this.stats,
+    required this.range,
+    required this.onRangeChanged,
+  });
+
+  final String friendName;
+  final FriendModel? friend;
+  final FriendHeadToHead stats;
+  final StatsTimeRange range;
+  final ValueChanged<StatsTimeRange?> onRangeChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    // No shared pods in the full history: the "go tag them" empty state. There
+    // is nothing to filter, so the dropdown is omitted here.
+    if (stats.sharedPods == 0 && range == StatsTimeRange.allTime) {
+      return _EmptyState(friendName: friendName);
+    }
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Align(
+            alignment: Alignment.centerRight,
+            child: _RangeDropdown(range: range, onChanged: onRangeChanged),
+          ),
+          const SizedBox(height: 8),
+          _Header(friendName: friendName, friend: friend, stats: stats),
+          const SizedBox(height: 16),
+          if (stats.sharedPods == 0)
+            const _NoPodsInRange()
+          else ...[
+            LedgerHeroTile(stats: stats, friendName: friendName),
+            const SizedBox(height: 16),
+            // The grid is intrinsically sized inside a scroll view. Tighter
+            // spacing and a shorter cell keep the cards close together.
+            GridView.count(
+              crossAxisCount: 3,
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              crossAxisSpacing: 12,
+              mainAxisSpacing: 12,
+              childAspectRatio: 1,
+              children: buildFriendStatTiles(stats),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// Right-aligned time-range selector, styled like the home stats dropdown.
+class _RangeDropdown extends StatelessWidget {
+  const _RangeDropdown({required this.range, required this.onChanged});
+
+  final StatsTimeRange range;
+  final ValueChanged<StatsTimeRange?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButton<StatsTimeRange>(
+      value: range,
+      dropdownColor: Colors.grey[900],
+      style: Theme.of(
+        context,
+      ).textTheme.bodyMedium?.copyWith(color: Colors.blueGrey),
+      underline: Container(height: 1, color: Colors.blueGrey.withAlpha(100)),
+      icon: const Icon(Icons.arrow_drop_down, color: Colors.blueGrey),
+      items: StatsTimeRange.values
+          .map(
+            (r) => DropdownMenuItem<StatsTimeRange>(
+              value: r,
+              child: Text(r.label),
+            ),
+          )
+          .toList(),
+      onChanged: onChanged,
+    );
+  }
+}
+
+/// Shown when the selected range has no shared pods but the friendship does —
+/// distinct from [_EmptyState], and leaves the dropdown visible to widen out.
+class _NoPodsInRange extends StatelessWidget {
+  const _NoPodsInRange();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 48, horizontal: 16),
+      child: Column(
+        children: [
+          const Icon(
+            Icons.filter_alt_off_outlined,
+            size: 48,
+            color: AppColors.tertiary,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'No shared pods in this range',
+            style: Theme.of(context).textTheme.titleMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Try a wider time range.',
+            style: Theme.of(
+              context,
+            ).textTheme.bodyMedium?.copyWith(color: AppColors.neutral60),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+Leave `_Header` and `_EmptyState` unchanged.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `flutter test test/friends_list/friend_stats/friend_stats_page_test.dart`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Run the full friend_stats suite and analyze**
+
+Run: `flutter test test/friends_list/friend_stats/`
+Expected: PASS.
+
+Run: `flutter analyze lib/friends_list/friend_stats`
+Expected: No issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/friends_list/friend_stats/view/friend_stats_page.dart \
+        test/friends_list/friend_stats/friend_stats_page_test.dart
+git commit -m "feat: time-range filter and tighter grid on friend head-to-head page"
+```
+
+---
+
+## Task 4: Manual verification in the running app
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the app (development flavor)**
+
+Run: `flutter run --flavor development --target lib/main_development.dart`
+
+- [ ] **Step 2: Verify each change**
+
+- Open a friend with shared pods (e.g. Cope357x). Confirm:
+  - The range dropdown appears top-right and defaults to "All Time".
+  - Tiles are cards with a caption line ("You · Them · Field", "You / Them survived", etc.) and sit close together (no large vertical gaps).
+  - Changing the range to "Last 3 Months"/"Last 30 Days" updates the header pod count, the Ledger, and the tiles.
+  - Narrowing to a range with no shared pods shows "No shared pods in this range" with the dropdown still visible; widening restores the stats.
+- Open a friend you have never shared a pod with: the original "No shared pods yet" empty state still shows.
+
+- [ ] **Step 3: Confirm no regression on home stats**
+
+Open the home stats overview; confirm its dropdown and tiles are unchanged.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Date filter drives whole page → Task 1 (bloc filter) + Task 3 (dropdown, header/Ledger/tiles all fed by filtered `compute`). ✓
+- Empty-in-range vs never-played → Task 3 `_NoPodsInRange` vs `_EmptyState`, gated on `range == allTime`. ✓
+- Tighter 3-column grid → Task 3 `childAspectRatio`/spacing + Card-filling `FriendStatCard`. ✓
+- Descriptive cards with captions → Task 2 `FriendStatCard` + caption table. ✓
+- `StatsWidget` untouched, calculator/model untouched → confirmed (only friend_stats files modified). ✓
+- Reuse `StatsTimeRange` → imported, not redefined. ✓
+
+**Placeholder scan:** No TBD/TODO; all steps carry full code. `childAspectRatio: 1` is a concrete starting value; Task 4 Step 2 is the visual check that confirms/adjusts it (adjust only if cards clip — a one-line change, not a placeholder). ✓
+
+**Type consistency:** `FriendStatsRangeChanged(StatsTimeRange)`, `FriendStatsLoaded(stats, {range})`, `FriendStatCard({title, stat, caption, tooltip})`, `buildFriendStatTiles(FriendHeadToHead)` used identically across tasks and tests. ✓

--- a/docs/superpowers/specs/2026-07-17-friend-stats-improvements-design.md
+++ b/docs/superpowers/specs/2026-07-17-friend-stats-improvements-design.md
@@ -1,0 +1,144 @@
+# Friend Head-to-Head Stats — Improvements
+
+**Date:** 2026-07-17
+**Status:** Approved, ready for implementation plan
+
+## Context
+
+The friend head-to-head stats page (`lib/friends_list/friend_stats/`) shipped in
+#70. It shows a Ledger hero tile plus a 3-column grid of secondary stats for the
+pods the signed-in user and one friend have played together. Three usability
+problems remain:
+
+1. **No date filter.** The home stats overview (`lib/stats_overview/`) has a
+   `StatsTimeRange` dropdown (All Time / Last 12/6/3 Months / Last 30 Days) that
+   filters games by `endTime`. The friend page has none — it always shows
+   all-time.
+2. **Tiles too far apart.** `GridView.count(crossAxisCount: 3,
+   childAspectRatio: 0.85, crossAxisSpacing: 24, mainAxisSpacing: 16)` makes each
+   cell taller than it is wide, so the fixed-size `StatsWidget` content floats in
+   large vertical gaps (visible on wide/tablet screens).
+3. **Titles aren't self-descriptive.** Each tile shows a terse title
+   ("Pods Won" → `6·3·6`, "Their Go-To", "Time Alive") whose meaning only lives
+   in a tooltip behind an info button.
+
+## Goals
+
+- Add a range filter that drives the **entire** friend page.
+- Tighten the grid so tiles sit close together.
+- Make each tile understandable at a glance, without opening the tooltip.
+
+## Non-goals
+
+- No changes to `FriendHeadToHeadCalculator` math or `FriendHeadToHead` model.
+- No changes to the shared `StatsWidget` (home stats still use it unchanged).
+- No column-count or max-width redesign — staying at 3 columns per the decision
+  below.
+
+## Design
+
+### 1. Date filter drives the whole page
+
+Reuse the existing `StatsTimeRange` enum from
+`lib/stats_overview/stats_overview_bloc/stats_overview_bloc.dart` (exported via
+the `stats_overview.dart` barrel) — do not duplicate it.
+
+`FriendStatsBloc` changes:
+- Retain the inputs as fields: `_allGames`, `_myId`, `_friendId`, and
+  `_range` (default `StatsTimeRange.allTime`).
+- `CompileFriendStats` populates `_allGames`/`_myId`/`_friendId`, then filters
+  and computes.
+- New event `FriendStatsRangeChanged(StatsTimeRange range)` updates `_range`,
+  then filters and computes from the retained fields.
+- A private `_filterGames(games, range)` mirrors the home-stats cutoff logic
+  (`allTime` → unfiltered; otherwise keep games whose `endTime.isAfter(cutoff)`,
+  with the same month/day cutoff arithmetic).
+- Compute stays synchronous, so **no generation fence is needed** (unlike home
+  stats, which awaits oracle-id resolution). The bloc's existing "computation is
+  synchronous and cheap" comment still holds.
+- `FriendStatsLoaded` carries the active `range` so the dropdown can reflect it.
+
+UI (`friend_stats_page.dart`):
+- A right-aligned `DropdownButton<StatsTimeRange>` at the top of the page body,
+  styled like the home dropdown (`_buildDropdown` pattern). Changing it dispatches
+  `FriendStatsRangeChanged`.
+- Because the filtered games flow through `compute`, the header
+  ("X pods together · since …"), the Ledger, and every tile all reflect the
+  selected range automatically — no separate wiring.
+
+### 2. Empty-in-range handling
+
+Two distinct empty states:
+- **No shared pods ever** (all-time `sharedPods == 0`): keep the existing
+  `_EmptyState` ("Once you and X play a pod together…, tag them into their
+  seat"). The dropdown may be hidden here — there is nothing to filter.
+- **Shared pods exist all-time but none in the selected range**: show a lighter
+  "No shared pods in this range" message **with the dropdown still visible**, so
+  the user can widen the range instead of being trapped.
+
+To distinguish these, the view needs to know whether *any* shared pods exist
+independent of the current range. Simplest approach: the page keeps the dropdown
+rendered whenever the state is `FriendStatsLoaded`, and swaps only the body
+(tiles vs. in-range-empty message) based on `stats.sharedPods`. The all-time
+"never played" case is the `sharedPods == 0` result of an `allTime` compile on
+first load. Implementation detail for the plan: distinguishing "never" from
+"none in range" can be done by checking whether `_range == allTime` — if the
+range is all-time and there are 0 pods, it's the "never" case; any narrower range
+with 0 pods is the "none in range" case.
+
+### 3. Tighter grid
+
+Keep `crossAxisCount: 3`. Reduce the vertical sprawl:
+- Lower `childAspectRatio` from `0.85` toward a shorter cell (wider-than-tall or
+  near-square — exact value tuned during implementation against the new card
+  height).
+- Reduce `crossAxisSpacing` and `mainAxisSpacing`.
+
+Goal is visual: collapse the large vertical gaps while keeping three columns.
+
+### 4. Self-descriptive card tiles
+
+New local widget `FriendStatCard` in `friend_stats_tiles.dart` (a `Card` matching
+`LedgerHeroTile`'s surface/padding style), rendering **title + value + caption**,
+with the info button retained for the full explanation. The shared `StatsWidget`
+is left untouched.
+
+`buildFriendStatTiles` returns `FriendStatCard`s with these title/caption pairs
+(values and sample-gates unchanged):
+
+| Title          | Value (unchanged)                 | Caption                  |
+|----------------|-----------------------------------|--------------------------|
+| Pods Won       | `6·3·6`                           | You · Them · Field       |
+| Their Go-To    | commander name                    | Most-played cmdr         |
+| Avg Time Alive | `97% / 93%`                       | You / Them survived      |
+| Final Two      | `1 of 15`                         | Last two standing        |
+| The Beatdown   | dealt / taken                     | Cmdr dmg dealt / taken   |
+| 21s            | landed / taken                    | Lethal 21s: you / them   |
+
+"Field" = the rest of the table's wins (you + them + field = total shared pods).
+Damage tiles (The Beatdown, 21s) remain omitted below their sample gates.
+
+Captions must survive narrow phones at 3 columns via `AutoSizeText` shrinking
+(the accepted tradeoff of keeping 3 columns).
+
+## Testing
+
+- **Bloc unit tests** (`friend_stats_bloc` test): `FriendStatsRangeChanged`
+  filters games by `endTime` and recomputes; an all-time compile followed by a
+  narrowed range emits a smaller `sharedPods`; range defaults to all-time on
+  first compile.
+- **Filter logic**: a game whose `endTime` is before the cutoff is excluded;
+  one after is included (mirror the home-stats boundary behavior).
+- **Widget smoke**: page renders the dropdown, tiles show captions, and the
+  "no shared pods in this range" body appears (with the dropdown still present)
+  when a narrowed range yields 0 pods.
+
+## Files touched
+
+- `lib/friends_list/friend_stats/friend_stats_bloc.dart` — range field, filter,
+  new event.
+- `lib/friends_list/friend_stats/friend_stats_event.dart` — `FriendStatsRangeChanged`.
+- `lib/friends_list/friend_stats/friend_stats_state.dart` — `range` on `FriendStatsLoaded`.
+- `lib/friends_list/friend_stats/view/friend_stats_page.dart` — dropdown, empty-in-range body, grid tuning.
+- `lib/friends_list/friend_stats/view/friend_stats_tiles.dart` — `FriendStatCard`, captions.
+- Tests under `test/friends_list/friend_stats/` (mirror existing structure).

--- a/lib/friends_list/friend_stats/friend_stats_bloc.dart
+++ b/lib/friends_list/friend_stats/friend_stats_bloc.dart
@@ -3,33 +3,74 @@ import 'package:equatable/equatable.dart';
 import 'package:firebase_database_repository/firebase_database_repository.dart';
 import 'package:magic_yeti/friends_list/friend_stats/friend_head_to_head.dart';
 import 'package:magic_yeti/friends_list/friend_stats/friend_head_to_head_calculator.dart';
+import 'package:magic_yeti/stats_overview/stats_overview.dart';
 
 part 'friend_stats_event.dart';
 part 'friend_stats_state.dart';
 
 /// Computes head-to-head stats between the signed-in user and one friend from
-/// the user's own match history.
+/// the user's own match history, over a selectable [StatsTimeRange].
 ///
-/// Games are injected via [CompileFriendStats] rather than fetched here — the
-/// friend page feeds them in from the app-wide match-history stream, mirroring
-/// how the stats overview is driven. Computation is synchronous and cheap, so
-/// no generation fence is needed.
+/// Games are injected via [CompileFriendStats] (from the app-wide
+/// match-history stream) and retained as fields so [FriendStatsRangeChanged]
+/// can re-filter and recompute without re-fetching. Computation is
+/// synchronous and cheap, so no generation fence is needed — events cannot
+/// interleave across an await here.
 class FriendStatsBloc extends Bloc<FriendStatsEvent, FriendStatsState> {
   FriendStatsBloc() : super(FriendStatsInitial()) {
     on<CompileFriendStats>(_onCompile);
+    on<FriendStatsRangeChanged>(_onRangeChanged);
   }
 
+  List<GameModel> _allGames = const [];
+  String _myId = '';
+  String _friendId = '';
+  StatsTimeRange _range = StatsTimeRange.allTime;
+
   void _onCompile(CompileFriendStats event, Emitter<FriendStatsState> emit) {
+    _allGames = event.games;
+    _myId = event.myId;
+    _friendId = event.friendId;
+    _emitCompiled(emit);
+  }
+
+  void _onRangeChanged(
+    FriendStatsRangeChanged event,
+    Emitter<FriendStatsState> emit,
+  ) {
+    _range = event.range;
+    _emitCompiled(emit);
+  }
+
+  void _emitCompiled(Emitter<FriendStatsState> emit) {
     emit(FriendStatsLoading());
     try {
+      final games = _filterGames(_allGames, _range);
       final stats = FriendHeadToHeadCalculator.compute(
-        games: event.games,
-        myId: event.myId,
-        friendId: event.friendId,
+        games: games,
+        myId: _myId,
+        friendId: _friendId,
       );
-      emit(FriendStatsLoaded(stats));
+      emit(FriendStatsLoaded(stats, range: _range));
     } on Object catch (error) {
       emit(FriendStatsFailure(error.toString()));
     }
+  }
+
+  /// Keeps games whose `endTime` is after the cutoff for [range]. Mirrors
+  /// `StatsOverviewBloc._filterGames` so the two pages agree on boundaries.
+  List<GameModel> _filterGames(List<GameModel> games, StatsTimeRange range) {
+    if (range == StatsTimeRange.allTime) {
+      return games;
+    }
+    final now = DateTime.now();
+    final cutoff = switch (range) {
+      StatsTimeRange.last12Months => DateTime(now.year - 1, now.month, now.day),
+      StatsTimeRange.last6Months => DateTime(now.year, now.month - 6, now.day),
+      StatsTimeRange.last3Months => DateTime(now.year, now.month - 3, now.day),
+      StatsTimeRange.last30Days => now.subtract(const Duration(days: 30)),
+      StatsTimeRange.allTime => now,
+    };
+    return games.where((game) => game.endTime.isAfter(cutoff)).toList();
   }
 }

--- a/lib/friends_list/friend_stats/friend_stats_event.dart
+++ b/lib/friends_list/friend_stats/friend_stats_event.dart
@@ -22,3 +22,14 @@ final class CompileFriendStats extends FriendStatsEvent {
   @override
   List<Object?> get props => [myId, friendId, games];
 }
+
+/// Change the time window the head-to-head stats are computed over. Reuses the
+/// retained games/ids from the last [CompileFriendStats].
+final class FriendStatsRangeChanged extends FriendStatsEvent {
+  const FriendStatsRangeChanged(this.range);
+
+  final StatsTimeRange range;
+
+  @override
+  List<Object?> get props => [range];
+}

--- a/lib/friends_list/friend_stats/friend_stats_state.dart
+++ b/lib/friends_list/friend_stats/friend_stats_state.dart
@@ -12,12 +12,13 @@ final class FriendStatsInitial extends FriendStatsState {}
 final class FriendStatsLoading extends FriendStatsState {}
 
 final class FriendStatsLoaded extends FriendStatsState {
-  const FriendStatsLoaded(this.stats);
+  const FriendStatsLoaded(this.stats, {this.range = StatsTimeRange.allTime});
 
   final FriendHeadToHead stats;
+  final StatsTimeRange range;
 
   @override
-  List<Object?> get props => [stats];
+  List<Object?> get props => [stats, range];
 }
 
 final class FriendStatsFailure extends FriendStatsState {

--- a/lib/friends_list/friend_stats/view/friend_stats_page.dart
+++ b/lib/friends_list/friend_stats/view/friend_stats_page.dart
@@ -161,22 +161,42 @@ class _FriendStatsBody extends StatelessWidget {
           else ...[
             LedgerHeroTile(stats: stats, friendName: friendName),
             const SizedBox(height: 16),
-            // The grid is intrinsically sized inside a scroll view. Tight
-            // spacing keeps the cards close together; the aspect ratio gives
-            // each cell enough height to fit its title/value/caption without
-            // overflow even for the longest content (a long commander name
-            // plus the two damage tiles) — FriendStatCard has no flex child,
-            // so AutoSizeText shrinks by width, not by the cell's height.
-            GridView.count(
-              crossAxisCount: 3,
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              crossAxisSpacing: 12,
-              mainAxisSpacing: 12,
-              childAspectRatio: 0.72,
-              children: buildFriendStatTiles(stats),
-            ),
+            _StatTiles(stats: stats),
           ],
+        ],
+      ),
+    );
+  }
+}
+
+/// The secondary stat cards, arranged per form factor. Phone: a 2-column grid
+/// whose cells stretch to fill width (short cells → tight, no overflow).
+/// Tablet/wide: a centered wrap of fixed-size cards so they cluster together
+/// instead of stretching across the screen into sparse, oversized cells.
+class _StatTiles extends StatelessWidget {
+  const _StatTiles({required this.stats});
+
+  final FriendHeadToHead stats;
+
+  @override
+  Widget build(BuildContext context) {
+    return AdaptiveLayout(
+      phone: (_) => GridView.count(
+        crossAxisCount: 2,
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        crossAxisSpacing: 12,
+        mainAxisSpacing: 12,
+        childAspectRatio: 1.1,
+        children: buildFriendStatTiles(stats),
+      ),
+      tablet: (_) => Wrap(
+        alignment: WrapAlignment.center,
+        spacing: 12,
+        runSpacing: 12,
+        children: [
+          for (final tile in buildFriendStatTiles(stats))
+            SizedBox(width: 190, height: 150, child: tile),
         ],
       ),
     );

--- a/lib/friends_list/friend_stats/view/friend_stats_page.dart
+++ b/lib/friends_list/friend_stats/view/friend_stats_page.dart
@@ -8,7 +8,7 @@ import 'package:magic_yeti/app/bloc/app_bloc.dart';
 import 'package:magic_yeti/friends_list/friend_stats/friend_stats.dart';
 import 'package:magic_yeti/friends_list/friend_stats/view/friend_stats_tiles.dart';
 import 'package:magic_yeti/home/match_history_bloc/match_history_bloc.dart';
-import 'package:magic_yeti/stats_overview/widgets/stats_overview_skeleton.dart';
+import 'package:magic_yeti/stats_overview/stats_overview.dart';
 
 /// Head-to-head stats between the signed-in user and one friend, over the pods
 /// they have played together.
@@ -78,6 +78,11 @@ class _FriendStatsViewState extends State<_FriendStatsView> {
     );
   }
 
+  void _onRangeChanged(StatsTimeRange? range) {
+    if (range == null) return;
+    context.read<FriendStatsBloc>().add(FriendStatsRangeChanged(range));
+  }
+
   String get _friendName => widget.friend?.username ?? 'Friend';
 
   @override
@@ -97,10 +102,12 @@ class _FriendStatsViewState extends State<_FriendStatsView> {
         child: BlocBuilder<FriendStatsBloc, FriendStatsState>(
           builder: (context, state) {
             return switch (state) {
-              FriendStatsLoaded(:final stats) => _FriendStatsBody(
+              FriendStatsLoaded(:final stats, :final range) => _FriendStatsBody(
                 friendName: _friendName,
                 friend: widget.friend,
                 stats: stats,
+                range: range,
+                onRangeChanged: _onRangeChanged,
               ),
               FriendStatsFailure() => const Center(
                 child: Text('Could not load these stats.'),
@@ -119,15 +126,21 @@ class _FriendStatsBody extends StatelessWidget {
     required this.friendName,
     required this.friend,
     required this.stats,
+    required this.range,
+    required this.onRangeChanged,
   });
 
   final String friendName;
   final FriendModel? friend;
   final FriendHeadToHead stats;
+  final StatsTimeRange range;
+  final ValueChanged<StatsTimeRange?> onRangeChanged;
 
   @override
   Widget build(BuildContext context) {
-    if (stats.sharedPods == 0) {
+    // No shared pods in the full history: the "go tag them" empty state. There
+    // is nothing to filter, so the dropdown is omitted here.
+    if (stats.sharedPods == 0 && range == StatsTimeRange.allTime) {
       return _EmptyState(friendName: friendName);
     }
 
@@ -136,19 +149,99 @@ class _FriendStatsBody extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
+          Align(
+            alignment: Alignment.centerRight,
+            child: _RangeDropdown(range: range, onChanged: onRangeChanged),
+          ),
+          const SizedBox(height: 8),
           _Header(friendName: friendName, friend: friend, stats: stats),
           const SizedBox(height: 16),
-          LedgerHeroTile(stats: stats, friendName: friendName),
-          const SizedBox(height: 16),
-          // The grid is intrinsically sized inside a scroll view.
-          GridView.count(
-            crossAxisCount: 3,
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            crossAxisSpacing: 24,
-            mainAxisSpacing: 16,
-            childAspectRatio: 0.85,
-            children: buildFriendStatTiles(stats),
+          if (stats.sharedPods == 0)
+            const _NoPodsInRange()
+          else ...[
+            LedgerHeroTile(stats: stats, friendName: friendName),
+            const SizedBox(height: 16),
+            // The grid is intrinsically sized inside a scroll view. Tight
+            // spacing keeps the cards close together; the aspect ratio gives
+            // each cell enough height to fit its title/value/caption without
+            // overflow even for the longest content (a long commander name
+            // plus the two damage tiles) — FriendStatCard has no flex child,
+            // so AutoSizeText shrinks by width, not by the cell's height.
+            GridView.count(
+              crossAxisCount: 3,
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              crossAxisSpacing: 12,
+              mainAxisSpacing: 12,
+              childAspectRatio: 0.72,
+              children: buildFriendStatTiles(stats),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// Right-aligned time-range selector, styled like the home stats dropdown.
+class _RangeDropdown extends StatelessWidget {
+  const _RangeDropdown({required this.range, required this.onChanged});
+
+  final StatsTimeRange range;
+  final ValueChanged<StatsTimeRange?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButton<StatsTimeRange>(
+      value: range,
+      dropdownColor: Colors.grey[900],
+      style: Theme.of(
+        context,
+      ).textTheme.bodyMedium?.copyWith(color: Colors.blueGrey),
+      underline: Container(height: 1, color: Colors.blueGrey.withAlpha(100)),
+      icon: const Icon(Icons.arrow_drop_down, color: Colors.blueGrey),
+      items: StatsTimeRange.values
+          .map(
+            (r) => DropdownMenuItem<StatsTimeRange>(
+              value: r,
+              child: Text(r.label),
+            ),
+          )
+          .toList(),
+      onChanged: onChanged,
+    );
+  }
+}
+
+/// Shown when the selected range has no shared pods but the friendship does —
+/// distinct from [_EmptyState], and leaves the dropdown visible to widen out.
+class _NoPodsInRange extends StatelessWidget {
+  const _NoPodsInRange();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 48, horizontal: 16),
+      child: Column(
+        children: [
+          const Icon(
+            Icons.filter_alt_off_outlined,
+            size: 48,
+            color: AppColors.tertiary,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'No shared pods in this range',
+            style: Theme.of(context).textTheme.titleMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Try a wider time range.',
+            style: Theme.of(
+              context,
+            ).textTheme.bodyMedium?.copyWith(color: AppColors.neutral60),
+            textAlign: TextAlign.center,
           ),
         ],
       ),

--- a/lib/friends_list/friend_stats/view/friend_stats_page.dart
+++ b/lib/friends_list/friend_stats/view/friend_stats_page.dart
@@ -284,10 +284,15 @@ class _Header extends StatelessWidget {
   Widget build(BuildContext context) {
     final imageUrl = friend?.profilePictureUrl ?? '';
     final since = stats.firstPlayedTogether;
-    final subtitle = since == null
-        ? '${stats.sharedPods} pods together'
-        : '${stats.sharedPods} pods together · since '
-              '${DateFormat('MMM yyyy').format(since)}';
+    // In the no-pods-in-range state the count is 0 and the body below already
+    // says "No shared pods in this range", so a "0 pods together" subtitle
+    // would just be redundant — drop it.
+    final subtitle = stats.sharedPods == 0
+        ? null
+        : since == null
+            ? '${stats.sharedPods} pods together'
+            : '${stats.sharedPods} pods together · since '
+                  '${DateFormat('MMM yyyy').format(since)}';
 
     return Row(
       children: [
@@ -315,12 +320,13 @@ class _Header extends StatelessWidget {
                 friendName,
                 style: Theme.of(context).textTheme.titleLarge,
               ),
-              Text(
-                subtitle,
-                style: Theme.of(
-                  context,
-                ).textTheme.bodyMedium?.copyWith(color: AppColors.neutral60),
-              ),
+              if (subtitle != null)
+                Text(
+                  subtitle,
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodyMedium?.copyWith(color: AppColors.neutral60),
+                ),
             ],
           ),
         ),

--- a/lib/friends_list/friend_stats/view/friend_stats_tiles.dart
+++ b/lib/friends_list/friend_stats/view/friend_stats_tiles.dart
@@ -90,7 +90,7 @@ class FriendStatCard extends StatelessWidget {
       color: AppColors.surface,
       margin: EdgeInsets.zero,
       child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 6),
+        padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 6),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
@@ -121,14 +121,14 @@ class FriendStatCard extends StatelessWidget {
                   ),
               ],
             ),
-            const SizedBox(height: 4),
+            const SizedBox(height: 3),
             AutoSizeText(
               stat,
               style: theme.textTheme.headlineSmall,
               textAlign: TextAlign.center,
               maxLines: 2,
             ),
-            const SizedBox(height: 4),
+            const SizedBox(height: 3),
             AutoSizeText(
               caption,
               style: theme.textTheme.bodySmall?.copyWith(

--- a/lib/friends_list/friend_stats/view/friend_stats_tiles.dart
+++ b/lib/friends_list/friend_stats/view/friend_stats_tiles.dart
@@ -1,7 +1,9 @@
+import 'dart:async';
+
 import 'package:app_ui/app_ui.dart';
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:magic_yeti/friends_list/friend_stats/friend_head_to_head.dart';
-import 'package:magic_yeti/stats_overview/widgets/stats_widget.dart';
 
 /// The hero tile: a pairwise finish record. This is the one stat with both a
 /// real sample and a real story at ~10 pods — "who finishes ahead" is defined
@@ -64,6 +66,105 @@ class LedgerHeroTile extends StatelessWidget {
   }
 }
 
+/// A single secondary head-to-head stat as a card: a clear title (with an
+/// optional info button for the full explanation), the value, and a caption
+/// that names what the value means so the info button is rarely needed.
+class FriendStatCard extends StatelessWidget {
+  const FriendStatCard({
+    required this.title,
+    required this.stat,
+    required this.caption,
+    this.tooltip,
+    super.key,
+  });
+
+  final String title;
+  final String stat;
+  final String caption;
+  final String? tooltip;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      color: AppColors.surface,
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 6),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Flexible(
+                  child: AutoSizeText(
+                    title,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      color: Colors.blueGrey,
+                    ),
+                    textAlign: TextAlign.center,
+                    maxLines: 1,
+                  ),
+                ),
+                if (tooltip != null)
+                  Padding(
+                    padding: const EdgeInsets.only(left: 2),
+                    child: GestureDetector(
+                      onTap: () => _showTooltip(context),
+                      child: Icon(
+                        Icons.info_outline,
+                        size: 10,
+                        color: Colors.blueGrey.withAlpha(150),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            AutoSizeText(
+              stat,
+              style: theme.textTheme.headlineSmall,
+              textAlign: TextAlign.center,
+              maxLines: 2,
+            ),
+            const SizedBox(height: 4),
+            AutoSizeText(
+              caption,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: AppColors.neutral60,
+              ),
+              textAlign: TextAlign.center,
+              maxLines: 2,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showTooltip(BuildContext context) {
+    unawaited(
+      showDialog<void>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: Text(
+            title,
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          content: Text(tooltip!),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 /// Builds the secondary stat tiles for the grid, applying each stat's sample
 /// gate. Damage tiles (The Beatdown, 21s) are omitted entirely below their
 /// gates rather than shown as a rivalry of zeroes.
@@ -71,57 +172,63 @@ List<Widget> buildFriendStatTiles(FriendHeadToHead stats) {
   int pct(double? f) => ((f ?? 0) * 100).round();
 
   return [
-    StatsWidget(
+    FriendStatCard(
       title: 'Pods Won',
       stat: stats.hasEnoughForLedger
           ? '${stats.youWon}·${stats.theyWon}·${stats.fieldWon}'
           : 'Need 3+',
+      caption: 'You · Them · Field',
       tooltip:
           'You · Them · Rest of the table, across ${stats.sharedPods} '
           'pods. An even split would be about '
           '${stats.expectedWinsEach.toStringAsFixed(1)} each — in a 4-player '
           'pod the baseline is 25%, not 50%.',
     ),
-    StatsWidget(
+    FriendStatCard(
       title: 'Their Go-To',
       stat: stats.hasEnoughForTopCommander
           ? (stats.theirTopCommanderName ?? 'Need 3+')
           : 'Need 3+',
+      caption: 'Most-played cmdr',
       tooltip: stats.hasEnoughForTopCommander
           ? 'The commander they bring to your table most often '
                 '(${stats.theirTopCommanderCount} of ${stats.sharedPods} pods).'
           : 'Their most-played commander at your table (needs 3+ pods).',
     ),
-    StatsWidget(
-      title: 'Time Alive',
+    FriendStatCard(
+      title: 'Avg Time Alive',
       stat: stats.hasEnoughForSurvival
           ? '${pct(stats.yourAvgSurvival)}% / ${pct(stats.theirAvgSurvival)}%'
           : 'Need 5+',
+      caption: 'You / Them survived',
       tooltip:
           'Average share of the pod each of you survives — you / them. '
           'The Ledger says who outlasts whom; this says by how much.',
     ),
-    StatsWidget(
+    FriendStatCard(
       title: 'Final Two',
       stat: stats.hasEnoughForFinalTwo
           ? '${stats.finalTwoCount} of ${stats.sharedPods}'
           : 'Need 5+',
+      caption: 'Last two standing',
       tooltip:
           'Pods where the two of you were the last players standing — '
           'the mark of a real rivalry.',
     ),
     if (stats.hasBeatdown)
-      StatsWidget(
+      FriendStatCard(
         title: 'The Beatdown',
         stat: '${stats.commanderDamageDealt} / ${stats.commanderDamageTaken}',
+        caption: 'Cmdr dmg dealt / taken',
         tooltip:
             'Total commander damage you have dealt to them / taken from '
             'them across your shared pods.',
       ),
     if (stats.hasLethalBlows)
-      StatsWidget(
+      FriendStatCard(
         title: '21s',
         stat: '${stats.lethalBlowsLanded} / ${stats.lethalBlowsTaken}',
+        caption: 'Lethal 21s: you / them',
         tooltip:
             'Pods where a single commander landed the lethal 21 — you on '
             'them / them on you.',

--- a/test/friends_list/friend_stats/friend_stats_bloc_test.dart
+++ b/test/friends_list/friend_stats/friend_stats_bloc_test.dart
@@ -2,6 +2,7 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:firebase_database_repository/firebase_database_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:magic_yeti/friends_list/friend_stats/friend_stats.dart';
+import 'package:magic_yeti/stats_overview/stats_overview.dart';
 import 'package:player_repository/player_repository.dart';
 
 Player _seat(String id, String firebaseId, int tod) => Player(
@@ -16,11 +17,11 @@ Player _seat(String id, String firebaseId, int tod) => Player(
   firebaseId: firebaseId,
 );
 
-GameModel _sharedGame() {
-  final start = DateTime(2026, 1, 1, 12);
-  final end = DateTime(2026, 1, 1, 14);
+/// A shared pod (me + friend) ending at [end]. `me` wins.
+GameModel _sharedGameAt(DateTime end) {
+  final start = end.subtract(const Duration(hours: 2));
   return GameModel(
-    id: 'g1',
+    id: 'g-${end.millisecondsSinceEpoch}',
     winnerId: 'me-seat',
     startTime: start,
     endTime: end,
@@ -35,22 +36,20 @@ GameModel _sharedGame() {
 void main() {
   group('FriendStatsBloc', () {
     blocTest<FriendStatsBloc, FriendStatsState>(
-      'emits loading then loaded with computed stats',
+      'emits loading then loaded with computed stats, range all-time',
       build: FriendStatsBloc.new,
       act: (bloc) => bloc.add(
         CompileFriendStats(
           myId: 'me',
           friendId: 'friend',
-          games: [_sharedGame()],
+          games: [_sharedGameAt(DateTime(2026, 1, 1, 14))],
         ),
       ),
       expect: () => [
         isA<FriendStatsLoading>(),
-        isA<FriendStatsLoaded>().having(
-          (s) => s.stats.sharedPods,
-          'sharedPods',
-          1,
-        ),
+        isA<FriendStatsLoaded>()
+            .having((s) => s.stats.sharedPods, 'sharedPods', 1)
+            .having((s) => s.range, 'range', StatsTimeRange.allTime),
       ],
     );
 
@@ -67,6 +66,34 @@ void main() {
           'sharedPods',
           0,
         ),
+      ],
+    );
+
+    blocTest<FriendStatsBloc, FriendStatsState>(
+      'range change filters games by endTime and recomputes',
+      build: FriendStatsBloc.new,
+      act: (bloc) {
+        final now = DateTime.now();
+        bloc
+          ..add(
+            CompileFriendStats(
+              myId: 'me',
+              friendId: 'friend',
+              games: [
+                _sharedGameAt(now.subtract(const Duration(days: 5))),
+                _sharedGameAt(now.subtract(const Duration(days: 400))),
+              ],
+            ),
+          )
+          ..add(const FriendStatsRangeChanged(StatsTimeRange.last30Days));
+      },
+      // Skip the loading+loaded pair emitted by the initial compile.
+      skip: 2,
+      expect: () => [
+        isA<FriendStatsLoading>(),
+        isA<FriendStatsLoaded>()
+            .having((s) => s.stats.sharedPods, 'sharedPods', 1)
+            .having((s) => s.range, 'range', StatsTimeRange.last30Days),
       ],
     );
   });

--- a/test/friends_list/friend_stats/friend_stats_page_test.dart
+++ b/test/friends_list/friend_stats/friend_stats_page_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:magic_yeti/app/bloc/app_bloc.dart';
 import 'package:magic_yeti/friends_list/friend_stats/view/friend_stats_page.dart';
 import 'package:magic_yeti/home/match_history_bloc/match_history_bloc.dart';
+import 'package:magic_yeti/stats_overview/stats_overview.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:player_repository/player_repository.dart';
 import 'package:user_repository/user_repository.dart';
@@ -17,29 +18,34 @@ class _MockMatchHistoryBloc
     extends MockBloc<MatchHistoryEvent, MatchHistoryState>
     implements MatchHistoryBloc {}
 
-Player _seat(String id, String firebaseId, int todMs, {String? commander}) =>
-    Player(
-      id: id,
-      name: 'Name-$id',
-      playerNumber: 0,
-      lifePoints: 40,
-      color: 0xFF000000,
-      opponents: const [],
-      placement: 1,
-      timeOfDeath: todMs,
-      firebaseId: firebaseId,
-      commander: commander == null
-          ? null
-          : Commander(
-              name: commander,
-              colors: const ['G'],
-              cardType: 'Legendary Creature',
-              imageUrl: '',
-              manaCost: '{G}',
-              oracleText: '',
-              artist: 'A',
-            ),
-    );
+Player _seat(
+  String id,
+  String firebaseId,
+  int todMs, {
+  String? commander,
+  List<Opponent> opponents = const [],
+}) => Player(
+  id: id,
+  name: 'Name-$id',
+  playerNumber: 0,
+  lifePoints: 40,
+  color: 0xFF000000,
+  opponents: opponents,
+  placement: 1,
+  timeOfDeath: todMs,
+  firebaseId: firebaseId,
+  commander: commander == null
+      ? null
+      : Commander(
+          name: commander,
+          colors: const ['G'],
+          cardType: 'Legendary Creature',
+          imageUrl: '',
+          manaCost: '{G}',
+          oracleText: '',
+          artist: 'A',
+        ),
+);
 
 /// A shared pod where `me` outlasts `friend` when [meAhead] is true.
 GameModel _pod(String id, {required bool meAhead}) {
@@ -133,8 +139,103 @@ void main() {
 
     // Secondary tiles are present.
     expect(find.text('Pods Won'), findsOneWidget);
-    expect(find.text('Time Alive'), findsOneWidget);
+    expect(find.text('Avg Time Alive'), findsOneWidget);
     expect(find.text('Their Go-To'), findsOneWidget);
+  });
+
+  testWidgets(
+    'does not overflow at phone width with every tile showing, including '
+    'The Beatdown, 21s, and a long commander name',
+    (tester) async {
+      // Phone-sized viewport — the crash this guards against only shows up
+      // under the 3-column grid's real (bounded) cell height.
+      tester.view.physicalSize = const Size(360, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      const longCommanderName = "Kroxa, Titan of Death's Hunger";
+      final start = DateTime(2026, 1, 1, 12);
+      final end = DateTime(2026, 1, 1, 14);
+
+      GameModel podWith({required String id, List<Opponent>? friendTakes}) {
+        return GameModel(
+          id: id,
+          winnerId: 'me-seat',
+          startTime: start,
+          endTime: end,
+          durationInSeconds: 7200,
+          players: [
+            _seat('me-seat', 'me', end.millisecondsSinceEpoch),
+            _seat(
+              'friend-seat',
+              'friend',
+              start.millisecondsSinceEpoch + 1000,
+              commander: longCommanderName,
+              opponents: friendTakes ?? const [],
+            ),
+          ],
+        );
+      }
+
+      stubHistory([
+        // The first pod lands a lethal 21 from me onto the friend, and
+        // clears the commander-damage-volume gate (>=21) in one shot —
+        // this makes both "The Beatdown" and "21s" tiles render.
+        podWith(
+          id: '1',
+          friendTakes: [
+            Opponent(
+              playerId: 'me-seat',
+              damages: [
+                CommanderDamage(damageType: DamageType.commander, amount: 21),
+              ],
+            ),
+          ],
+        ),
+        podWith(id: '2'),
+        podWith(id: '3'),
+        podWith(id: '4'),
+        podWith(id: '5'),
+      ]);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      // Sanity: the long-caption tiles are actually present, so this test
+      // exercises the overflow-prone cards rather than trivially passing.
+      expect(find.text('The Beatdown'), findsOneWidget);
+      expect(find.text('21s'), findsOneWidget);
+      expect(find.text(longCommanderName), findsOneWidget);
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('shows an in-range empty body when the range hides all pods', (
+    tester,
+  ) async {
+    // Pods dated Jan 2026 — outside a Last-30-Days window as of the run date.
+    stubHistory([
+      _pod('1', meAhead: true),
+      _pod('2', meAhead: true),
+      _pod('3', meAhead: true),
+    ]);
+
+    await tester.pumpWidget(buildSubject());
+    await tester.pumpAndSettle();
+
+    // Open the range dropdown and pick Last 30 Days.
+    await tester.tap(find.byType(DropdownButton<StatsTimeRange>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Last 30 Days').last);
+    await tester.pumpAndSettle();
+
+    // In-range empty message shows, and the dropdown is still available to
+    // widen the range back out.
+    expect(find.textContaining('No shared pods in this range'), findsOneWidget);
+    expect(find.byType(DropdownButton<StatsTimeRange>), findsOneWidget);
+    // Not the all-time "never played" empty state.
+    expect(find.textContaining('No shared pods yet'), findsNothing);
   });
 
   testWidgets('shows the empty state when no pods are shared', (tester) async {

--- a/test/friends_list/friend_stats/friend_stats_page_test.dart
+++ b/test/friends_list/friend_stats/friend_stats_page_test.dart
@@ -163,7 +163,7 @@ void main() {
     'The Beatdown, 21s, and a long commander name',
     (tester) async {
       // Phone-sized viewport — the crash this guards against only shows up
-      // under the 3-column grid's real (bounded) cell height.
+      // under the 2-column grid's real (bounded) cell height.
       tester.view.physicalSize = const Size(360, 800);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.reset);

--- a/test/friends_list/friend_stats/friend_stats_page_test.dart
+++ b/test/friends_list/friend_stats/friend_stats_page_test.dart
@@ -118,6 +118,21 @@ void main() {
     );
   }
 
+  Widget buildTabletSubject() {
+    return MaterialApp(
+      home: DeviceInfoProvider(
+        isPhone: false,
+        child: MultiBlocProvider(
+          providers: [
+            BlocProvider<AppBloc>.value(value: appBloc),
+            BlocProvider<MatchHistoryBloc>.value(value: matchHistoryBloc),
+          ],
+          child: const FriendStatsPage(friendId: 'friend', friend: _friend),
+        ),
+      ),
+    );
+  }
+
   testWidgets('renders head-to-head stats for the shared pods', (tester) async {
     stubHistory([
       _pod('1', meAhead: true),
@@ -206,6 +221,79 @@ void main() {
       expect(find.text('The Beatdown'), findsOneWidget);
       expect(find.text('21s'), findsOneWidget);
       expect(find.text(longCommanderName), findsOneWidget);
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'does not overflow at tablet width and renders the Wrap layout, not the '
+    'phone grid, with every tile showing',
+    (tester) async {
+      // Wide viewport — exercises the tablet/wide AdaptiveLayout branch.
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      const longCommanderName = "Kroxa, Titan of Death's Hunger";
+      final start = DateTime(2026, 1, 1, 12);
+      final end = DateTime(2026, 1, 1, 14);
+
+      GameModel podWith({required String id, List<Opponent>? friendTakes}) {
+        return GameModel(
+          id: id,
+          winnerId: 'me-seat',
+          startTime: start,
+          endTime: end,
+          durationInSeconds: 7200,
+          players: [
+            _seat('me-seat', 'me', end.millisecondsSinceEpoch),
+            _seat(
+              'friend-seat',
+              'friend',
+              start.millisecondsSinceEpoch + 1000,
+              commander: longCommanderName,
+              opponents: friendTakes ?? const [],
+            ),
+          ],
+        );
+      }
+
+      stubHistory([
+        // The first pod lands a lethal 21 from me onto the friend, and
+        // clears the commander-damage-volume gate (>=21) in one shot —
+        // this makes both "The Beatdown" and "21s" tiles render.
+        podWith(
+          id: '1',
+          friendTakes: [
+            Opponent(
+              playerId: 'me-seat',
+              damages: [
+                CommanderDamage(damageType: DamageType.commander, amount: 21),
+              ],
+            ),
+          ],
+        ),
+        podWith(id: '2'),
+        podWith(id: '3'),
+        podWith(id: '4'),
+        podWith(id: '5'),
+      ]);
+
+      await tester.pumpWidget(buildTabletSubject());
+      await tester.pumpAndSettle();
+
+      // Sanity: the long-caption tiles are actually present, so this test
+      // exercises the overflow-prone cards rather than trivially passing.
+      expect(find.text('The Beatdown'), findsOneWidget);
+      expect(find.text('21s'), findsOneWidget);
+      expect(find.text(longCommanderName), findsOneWidget);
+
+      // The tablet path renders a Wrap of fixed-size cards, not the phone
+      // GridView.
+      expect(find.byType(Wrap), findsWidgets);
+      expect(find.byType(GridView), findsNothing);
 
       expect(tester.takeException(), isNull);
     },

--- a/test/friends_list/friend_stats/friend_stats_tiles_test.dart
+++ b/test/friends_list/friend_stats/friend_stats_tiles_test.dart
@@ -129,8 +129,18 @@ void main() {
       await _pump(tester, Column(children: tiles));
 
       // Time Alive tile present but showing the need-more sentinel.
-      expect(find.text('Time Alive'), findsOneWidget);
+      expect(find.text('Avg Time Alive'), findsOneWidget);
       expect(find.text('Need 5+'), findsWidgets);
+    });
+
+    testWidgets('renders captions under the values', (tester) async {
+      final tiles = buildFriendStatTiles(
+        _stats(sharedPods: 5, youWon: 3, theyWon: 1, fieldWon: 1),
+      );
+      await _pump(tester, Column(children: tiles));
+
+      expect(find.text('You · Them · Field'), findsOneWidget);
+      expect(find.text('3·1·1'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Improves the friend head-to-head stats page based on user feedback (three asks).

## What changed

**1. Date-range filter (drives the whole page)**
- Reuses the home stats `StatsTimeRange` dropdown (All Time / Last 12·6·3 Months / Last 30 Days).
- `FriendStatsBloc` retains the compiled inputs and re-filters games by `endTime` + recomputes on a new `FriendStatsRangeChanged` event (synchronous — no generation fence needed).
- Filtering flows through `FriendHeadToHeadCalculator.compute`, so the header ("N pods together"), the Ledger, and every tile all reflect the selected range.
- Distinct empty states: all-time-never-played ("No shared pods yet — tag them") vs. **no-pods-in-range** ("No shared pods in this range") which keeps the dropdown visible so you can widen back out.

**2. Responsive two-view layout (fixes wide-screen sprawl)**
- Uses the app's `AdaptiveLayout(phone/tablet)` convention.
- **Phone:** stat cards in a tight 2-column grid.
- **Tablet/wide:** stat cards as fixed-size cards clustered in a centered `Wrap`, instead of a single 3-column grid stretched edge-to-edge with large gaps.
- Overflow-guarded at both widths with non-vacuous widget tests (worst-case content: long commander name + both damage tiles).

**3. Self-descriptive tiles**
- New local `FriendStatCard` (title + value + **caption**) replaces `StatsWidget` in the friend grid; e.g. Pods Won → `You · Them · Field`, Avg Time Alive → `You / Them survived`. The info button stays for full detail.
- Shared `StatsWidget`, `FriendHeadToHeadCalculator`, and the `FriendHeadToHead` model are untouched.

## Verification
- Full root suite **218/218**, friend-stats suite **28/28**, `flutter analyze` clean on touched files.
- Both layouts rendered and visually confirmed (tight phone grid; centered tablet cluster; no overflow).
- Not done: live on-device check (no device/Firestore in this session).

## Deferred follow-ups (non-blocking, from review)
- Range dropdown hardcodes `Colors.grey[900]`/`Colors.blueGrey` (a deliberate mirror of the home dropdown — candidate for a shared themed widget).
- `_StatTiles` magic numbers (`childAspectRatio: 1.1`, `SizedBox(190×150)`) could use an inline comment about the no-flex-child / AutoSizeText-width-only constraint.
- Cutoff date math is duplicated between `friend_stats_bloc` and `StatsOverviewBloc` (shared code was off-limits for this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)